### PR TITLE
feat(backend): Makefile作成

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,26 @@
+.PHONY: help run sqlc-generate migrate-up migrate-down test build clean
+
+help: ## Show this help message
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+run: ## Run the server
+	go run cmd/server/main.go
+
+sqlc-generate: ## Generate sqlc code
+	sqlc generate
+
+migrate-up: ## Run migrations up
+	# TODO: マイグレーションツール導入後に実装
+
+migrate-down: ## Run migrations down
+	# TODO: マイグレーションツール導入後に実装
+
+test: ## Run tests
+	go test -v ./...
+
+build: ## Build the binary
+	go build -o bin/server cmd/server/main.go
+
+clean: ## Clean build artifacts
+	rm -rf bin/


### PR DESCRIPTION
## Summary
- `backend/Makefile` を作成し、開発コマンドのショートカットを定義
- `make help` で全ターゲットの説明を表示

## Test plan
- [x] `make help` で全ターゲットが表示される
- [ ] `make run` でサーバー起動（サーバー実装後に確認）
- [ ] `make sqlc-generate` でコード生成（sqlcインストール後に確認）
- [ ] `make test` でテスト実行
- [ ] `make build` でバイナリ生成
- [ ] `make clean` でビルド成果物削除

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)