### PR TITLE
feat(infra): PostgreSQLコンテナの起動設定

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  db:
+    image: postgres:15-alpine
+    container_name: coffee_stock_db
+    environment:
+      POSTGRES_DB: coffee_stock
+      POSTGRES_USER: coffee_user
+      POSTGRES_PASSWORD: coffee_pass
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./backend/sql/schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U coffee_user -d coffee_stock"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- `docker-compose.yml` を作成し、PostgreSQL 15コンテナを定義
- `schema.sql` を initdb.d にマウントして起動時に自動でテーブル作成
- ヘルスチェック（`pg_isready`）と永続化ボリュームを設定

## Test plan
- [x] `docker compose up -d` でコンテナ起動
- [x] ヘルスチェックが healthy
- [x] `psql` で接続可能
- [x] 4テーブル（users, coffee_beans, purchase_history, usage_history）が作成済み
- [x] `coffee_user` ユーザーが存在

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)