### PR TITLE
feat(backend): golang-migrateによるマイグレーション設定

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,3 +1,6 @@
+DB_URL ?= postgres://coffee_user:coffee_pass@localhost:5432/coffee_stock?sslmode=disable
+MIGRATIONS_DIR = migrations
+
 .PHONY: help run sqlc-generate migrate-up migrate-down test build clean
 
 help: ## Show this help message
@@ -11,10 +14,10 @@ sqlc-generate: ## Generate sqlc code
 	sqlc generate
 
 migrate-up: ## Run migrations up
-	# TODO: マイグレーションツール導入後に実装
+	$(GOBIN)/migrate -path $(MIGRATIONS_DIR) -database "$(DB_URL)" up
 
-migrate-down: ## Run migrations down
-	# TODO: マイグレーションツール導入後に実装
+migrate-down: ## Run migrations down (1 step)
+	$(GOBIN)/migrate -path $(MIGRATIONS_DIR) -database "$(DB_URL)" down 1
 
 test: ## Run tests
 	go test -v ./...

--- a/backend/migrations/000001_create_initial_tables.down.sql
+++ b/backend/migrations/000001_create_initial_tables.down.sql
@@ -1,0 +1,7 @@
+DROP TABLE IF EXISTS usage_history;
+DROP TABLE IF EXISTS purchase_history;
+DROP TABLE IF EXISTS coffee_beans;
+DROP TABLE IF EXISTS users;
+
+DROP EXTENSION IF EXISTS "pgcrypto";
+DROP EXTENSION IF EXISTS "uuid-ossp";

--- a/backend/migrations/000001_create_initial_tables.up.sql
+++ b/backend/migrations/000001_create_initial_tables.up.sql
@@ -1,0 +1,102 @@
+-- Enable UUID extension
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- Users table
+CREATE TABLE users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    low_stock_threshold INTEGER NOT NULL DEFAULT 100,
+    notification_enabled BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP WITH TIME ZONE
+);
+
+-- Coffee beans table (master data without purchase info)
+CREATE TABLE coffee_beans (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    name VARCHAR(200) NOT NULL,
+    origin VARCHAR(100),
+    roast_level VARCHAR(50),
+    current_stock INTEGER NOT NULL CHECK (current_stock >= 0),
+    notes TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP WITH TIME ZONE,
+
+    CONSTRAINT fk_coffee_beans_user
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE
+);
+
+-- Purchase history table (separated from coffee_beans)
+CREATE TABLE purchase_history (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    coffee_bean_id UUID NOT NULL,
+    user_id UUID NOT NULL,
+    purchase_date DATE NOT NULL,
+    purchase_price DECIMAL(10, 2),
+    purchase_store VARCHAR(200),
+    quantity INTEGER NOT NULL CHECK (quantity > 0),
+    notes TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_purchase_history_coffee_bean
+        FOREIGN KEY (coffee_bean_id)
+        REFERENCES coffee_beans(id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_purchase_history_user
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE
+);
+
+-- Usage history table
+CREATE TABLE usage_history (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    coffee_bean_id UUID NOT NULL,
+    user_id UUID NOT NULL,
+    usage_date DATE NOT NULL,
+    quantity INTEGER NOT NULL CHECK (quantity > 0),
+    usage_type VARCHAR(50) NOT NULL,
+    notes TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_usage_history_coffee_bean
+        FOREIGN KEY (coffee_bean_id)
+        REFERENCES coffee_beans(id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_usage_history_user
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT check_usage_type
+        CHECK (usage_type IN ('manual', 'quick_button'))
+);
+
+-- Indexes for users
+CREATE INDEX idx_users_email ON users(email) WHERE deleted_at IS NULL;
+
+-- Indexes for coffee_beans
+CREATE INDEX idx_coffee_beans_user_id ON coffee_beans(user_id) WHERE deleted_at IS NULL;
+CREATE INDEX idx_coffee_beans_updated_at ON coffee_beans(updated_at DESC) WHERE deleted_at IS NULL;
+
+-- Indexes for purchase_history
+CREATE INDEX idx_purchase_history_coffee_bean_id ON purchase_history(coffee_bean_id);
+CREATE INDEX idx_purchase_history_user_id ON purchase_history(user_id);
+CREATE INDEX idx_purchase_history_purchase_date ON purchase_history(purchase_date DESC);
+CREATE INDEX idx_purchase_history_coffee_bean_date ON purchase_history(coffee_bean_id, purchase_date DESC);
+
+-- Indexes for usage_history
+CREATE INDEX idx_usage_history_coffee_bean_id ON usage_history(coffee_bean_id);
+CREATE INDEX idx_usage_history_user_id ON usage_history(user_id);
+CREATE INDEX idx_usage_history_usage_date ON usage_history(usage_date DESC);
+CREATE INDEX idx_usage_history_coffee_bean_date ON usage_history(coffee_bean_id, usage_date DESC);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./backend/sql/schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U coffee_user -d coffee_stock"]
       interval: 5s


### PR DESCRIPTION
## Summary
- 初回マイグレーションファイル (`000001_create_initial_tables`) を作成
- Makefileの `migrate-up` / `migrate-down` を golang-migrate で実装
- docker-compose.yml から initdb.d マウントを削除し、マイグレーションでスキーマ管理

## Test plan
- [x] `make migrate-up` で全テーブル作成
- [x] `make migrate-down` でロールバック（テーブル削除）
- [x] up/down の往復が正常動作

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)