### PR TITLE
feat(backend): JWT認証API実装（signup, login, refresh, me）

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -11,9 +11,14 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/chi/v5/middleware"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/api/handlers"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/api/middleware"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/auth"
 	"github.com/k3forx/CoffeeBeansStock/backend/internal/config"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/database"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/services"
 )
 
 func main() {
@@ -40,10 +45,15 @@ func main() {
 	}
 	slog.Info("database connection established")
 
+	queries := database.New(pool)
+	jwtManager := auth.NewJWTManager(cfg.JWTSecret)
+	authService := services.NewAuthService(queries, jwtManager)
+	authHandler := handlers.NewAuthHandler(authService)
+
 	r := chi.NewRouter()
-	r.Use(middleware.RequestID)
-	r.Use(middleware.RealIP)
-	r.Use(middleware.Recoverer)
+	r.Use(chimiddleware.RequestID)
+	r.Use(chimiddleware.RealIP)
+	r.Use(chimiddleware.Recoverer)
 
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -54,6 +64,19 @@ func main() {
 		}
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, `{"status":"ok","database":"connected"}`)
+	})
+
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Route("/auth", func(r chi.Router) {
+			r.Post("/signup", authHandler.Signup)
+			r.Post("/login", authHandler.Login)
+			r.Post("/refresh", authHandler.Refresh)
+
+			r.Group(func(r chi.Router) {
+				r.Use(middleware.Auth(jwtManager))
+				r.Get("/me", authHandler.GetMe)
+			})
+		})
 	})
 
 	srv := &http.Server{

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,14 +4,17 @@ go 1.26.0
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5
+	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.1
 	github.com/joho/godotenv v1.5.1
+	golang.org/x/crypto v0.49.0
 )
 
 require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	golang.org/x/sync v0.17.0 // indirect
-	golang.org/x/text v0.29.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/text v0.35.0 // indirect
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -3,6 +3,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
@@ -20,10 +24,12 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
-golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
-golang.org/x/text v0.29.0 h1:1neNs90w9YzJ9BocxfsQNHKuAT4pkghyXc4nhZ6sJvk=
-golang.org/x/text v0.29.0/go.mod h1:7MhJOA9CD2qZyOKYazxdYMF85OwPdEr9jTtBpO7ydH4=
+golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
+golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
+golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/backend/internal/api/handlers/auth_handler.go
+++ b/backend/internal/api/handlers/auth_handler.go
@@ -1,0 +1,147 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/api"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/api/middleware"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/auth"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/services"
+)
+
+type AuthHandler struct {
+	authService *services.AuthService
+}
+
+func NewAuthHandler(authService *services.AuthService) *AuthHandler {
+	return &AuthHandler{authService: authService}
+}
+
+type signupRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+	Name     string `json:"name"`
+}
+
+type loginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type refreshRequest struct {
+	RefreshToken string `json:"refresh_token"`
+}
+
+func (h *AuthHandler) Signup(w http.ResponseWriter, r *http.Request) {
+	var req signupRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		api.WriteError(w, http.StatusBadRequest, "BAD_REQUEST", "リクエストの形式が不正です")
+		return
+	}
+
+	input := &services.SignupInput{
+		Email:    req.Email,
+		Password: req.Password,
+		Name:     req.Name,
+	}
+
+	if errs := h.authService.ValidateSignupInput(input); len(errs) > 0 {
+		api.WriteValidationError(w, toAPIFieldErrors(errs))
+		return
+	}
+
+	result, err := h.authService.Signup(r.Context(), input)
+	if err != nil {
+		if errors.Is(err, services.ErrEmailAlreadyExists) {
+			api.WriteError(w, http.StatusConflict, "CONFLICT", "このメールアドレスは既に登録されています")
+			return
+		}
+		api.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "サーバーエラーが発生しました")
+		return
+	}
+
+	api.WriteSuccess(w, http.StatusCreated, result)
+}
+
+func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
+	var req loginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		api.WriteError(w, http.StatusBadRequest, "BAD_REQUEST", "リクエストの形式が不正です")
+		return
+	}
+
+	input := &services.LoginInput{
+		Email:    req.Email,
+		Password: req.Password,
+	}
+
+	if errs := h.authService.ValidateLoginInput(input); len(errs) > 0 {
+		api.WriteValidationError(w, toAPIFieldErrors(errs))
+		return
+	}
+
+	result, err := h.authService.Login(r.Context(), input)
+	if err != nil {
+		if errors.Is(err, services.ErrInvalidCredentials) {
+			api.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "メールアドレスまたはパスワードが正しくありません")
+			return
+		}
+		api.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "サーバーエラーが発生しました")
+		return
+	}
+
+	api.WriteSuccess(w, http.StatusOK, result)
+}
+
+func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
+	var req refreshRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		api.WriteError(w, http.StatusBadRequest, "BAD_REQUEST", "リクエストの形式が不正です")
+		return
+	}
+
+	if req.RefreshToken == "" {
+		api.WriteValidationError(w, []api.FieldError{
+			{Field: "refresh_token", Message: "リフレッシュトークンは必須です"},
+		})
+		return
+	}
+
+	result, err := h.authService.Refresh(r.Context(), req.RefreshToken)
+	if err != nil {
+		if errors.Is(err, auth.ErrInvalidToken) || errors.Is(err, auth.ErrExpiredToken) {
+			api.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "リフレッシュトークンが無効です")
+			return
+		}
+		api.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "サーバーエラーが発生しました")
+		return
+	}
+
+	api.WriteSuccess(w, http.StatusOK, result)
+}
+
+func (h *AuthHandler) GetMe(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.GetUserID(r.Context())
+	if !ok {
+		api.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "認証が必要です")
+		return
+	}
+
+	user, err := h.authService.GetMe(r.Context(), userID)
+	if err != nil {
+		api.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "サーバーエラーが発生しました")
+		return
+	}
+
+	api.WriteSuccess(w, http.StatusOK, user)
+}
+
+func toAPIFieldErrors(errs []services.FieldError) []api.FieldError {
+	result := make([]api.FieldError, len(errs))
+	for i, e := range errs {
+		result[i] = api.FieldError{Field: e.Field, Message: e.Message}
+	}
+	return result
+}

--- a/backend/internal/api/middleware/auth.go
+++ b/backend/internal/api/middleware/auth.go
@@ -1,0 +1,53 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/api"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/auth"
+)
+
+type contextKey string
+
+const userIDKey contextKey = "userID"
+
+func Auth(jwtManager *auth.JWTManager) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			header := r.Header.Get("Authorization")
+			if header == "" {
+				api.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "認証トークンが必要です")
+				return
+			}
+
+			parts := strings.SplitN(header, " ", 2)
+			if len(parts) != 2 || parts[0] != "Bearer" {
+				api.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "認証トークンの形式が不正です")
+				return
+			}
+
+			claims, err := jwtManager.ValidateToken(parts[1])
+			if err != nil {
+				api.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "認証トークンが無効です")
+				return
+			}
+
+			userID, err := uuid.Parse(claims.UserID)
+			if err != nil {
+				api.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "認証トークンが無効です")
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), userIDKey, userID)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+func GetUserID(ctx context.Context) (uuid.UUID, bool) {
+	id, ok := ctx.Value(userIDKey).(uuid.UUID)
+	return id, ok
+}

--- a/backend/internal/api/response.go
+++ b/backend/internal/api/response.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Response struct {
+	Success bool        `json:"success"`
+	Data    interface{} `json:"data,omitempty"`
+	Error   *ErrorBody  `json:"error,omitempty"`
+}
+
+type ErrorBody struct {
+	Code    string        `json:"code"`
+	Message string        `json:"message"`
+	Details []FieldError  `json:"details,omitempty"`
+}
+
+type FieldError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+func WriteJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}
+
+func WriteSuccess(w http.ResponseWriter, status int, data interface{}) {
+	WriteJSON(w, status, Response{Success: true, Data: data})
+}
+
+func WriteError(w http.ResponseWriter, status int, code, message string) {
+	WriteJSON(w, status, Response{
+		Success: false,
+		Error:   &ErrorBody{Code: code, Message: message},
+	})
+}
+
+func WriteValidationError(w http.ResponseWriter, details []FieldError) {
+	WriteJSON(w, http.StatusBadRequest, Response{
+		Success: false,
+		Error: &ErrorBody{
+			Code:    "VALIDATION_ERROR",
+			Message: "入力値が不正です",
+			Details: details,
+		},
+	})
+}

--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -1,0 +1,92 @@
+package auth
+
+import (
+	"errors"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+)
+
+var (
+	ErrInvalidToken = errors.New("invalid token")
+	ErrExpiredToken = errors.New("expired token")
+)
+
+const (
+	AccessTokenDuration  = 1 * time.Hour
+	RefreshTokenDuration = 7 * 24 * time.Hour
+)
+
+type TokenClaims struct {
+	UserID string `json:"user_id"`
+	Email  string `json:"email,omitempty"`
+	jwt.RegisteredClaims
+}
+
+type TokenPair struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+type JWTManager struct {
+	secret []byte
+}
+
+func NewJWTManager(secret string) *JWTManager {
+	return &JWTManager{secret: []byte(secret)}
+}
+
+func (m *JWTManager) GenerateTokenPair(userID uuid.UUID, email string) (*TokenPair, error) {
+	accessToken, err := m.generateToken(userID.String(), email, AccessTokenDuration)
+	if err != nil {
+		return nil, err
+	}
+
+	refreshToken, err := m.generateToken(userID.String(), "", RefreshTokenDuration)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TokenPair{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+	}, nil
+}
+
+func (m *JWTManager) ValidateToken(tokenStr string) (*TokenClaims, error) {
+	token, err := jwt.ParseWithClaims(tokenStr, &TokenClaims{}, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, ErrInvalidToken
+		}
+		return m.secret, nil
+	})
+	if err != nil {
+		if errors.Is(err, jwt.ErrTokenExpired) {
+			return nil, ErrExpiredToken
+		}
+		return nil, ErrInvalidToken
+	}
+
+	claims, ok := token.Claims.(*TokenClaims)
+	if !ok || !token.Valid {
+		return nil, ErrInvalidToken
+	}
+
+	return claims, nil
+}
+
+func (m *JWTManager) generateToken(userID, email string, duration time.Duration) (string, error) {
+	now := time.Now()
+	claims := &TokenClaims{
+		UserID: userID,
+		Email:  email,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(now.Add(duration)),
+			IssuedAt:  jwt.NewNumericDate(now),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(m.secret)
+}

--- a/backend/internal/auth/password.go
+++ b/backend/internal/auth/password.go
@@ -1,0 +1,17 @@
+package auth
+
+import "golang.org/x/crypto/bcrypt"
+
+const bcryptCost = 10
+
+func HashPassword(password string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcryptCost)
+	if err != nil {
+		return "", err
+	}
+	return string(hash), nil
+}
+
+func CheckPassword(hash, password string) error {
+	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	DBPass    string
 	DBName    string
 	DBSSLMode string
+	JWTSecret string
 }
 
 func Load() (*Config, error) {
@@ -28,6 +29,7 @@ func Load() (*Config, error) {
 		DBPass:    getEnv("DB_PASSWORD", "coffee_pass"),
 		DBName:    getEnv("DB_NAME", "coffee_stock"),
 		DBSSLMode: getEnv("DB_SSLMODE", "disable"),
+		JWTSecret: getEnv("JWT_SECRET", "dev-secret-change-in-production"),
 	}
 
 	return cfg, nil

--- a/backend/internal/services/auth_service.go
+++ b/backend/internal/services/auth_service.go
@@ -1,0 +1,250 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"net/mail"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/auth"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/database"
+)
+
+var (
+	ErrEmailAlreadyExists = errors.New("email already exists")
+	ErrInvalidCredentials = errors.New("invalid credentials")
+)
+
+type AuthService struct {
+	queries    *database.Queries
+	jwtManager *auth.JWTManager
+}
+
+func NewAuthService(queries *database.Queries, jwtManager *auth.JWTManager) *AuthService {
+	return &AuthService{queries: queries, jwtManager: jwtManager}
+}
+
+type SignupInput struct {
+	Email    string
+	Password string
+	Name     string
+}
+
+type LoginInput struct {
+	Email    string
+	Password string
+}
+
+type AuthResult struct {
+	User        *UserResponse     `json:"user"`
+	AccessToken string            `json:"access_token"`
+	RefreshToken string           `json:"refresh_token"`
+}
+
+type UserResponse struct {
+	ID        uuid.UUID `json:"id"`
+	Email     string    `json:"email"`
+	Name      string    `json:"name"`
+	LowStockThreshold  int32  `json:"low_stock_threshold,omitempty"`
+	NotificationEnabled bool   `json:"notification_enabled,omitempty"`
+	CreatedAt string    `json:"created_at"`
+	UpdatedAt string    `json:"updated_at,omitempty"`
+}
+
+func (s *AuthService) ValidateSignupInput(input *SignupInput) []FieldError {
+	var errs []FieldError
+
+	input.Email = strings.TrimSpace(input.Email)
+	input.Name = strings.TrimSpace(input.Name)
+
+	if input.Email == "" {
+		errs = append(errs, FieldError{Field: "email", Message: "メールアドレスは必須です"})
+	} else if _, err := mail.ParseAddress(input.Email); err != nil {
+		errs = append(errs, FieldError{Field: "email", Message: "有効なメールアドレスを入力してください"})
+	}
+
+	if input.Password == "" {
+		errs = append(errs, FieldError{Field: "password", Message: "パスワードは必須です"})
+	} else if len(input.Password) < 8 {
+		errs = append(errs, FieldError{Field: "password", Message: "パスワードは8文字以上で入力してください"})
+	}
+
+	if input.Name == "" {
+		errs = append(errs, FieldError{Field: "name", Message: "名前は必須です"})
+	} else if len(input.Name) > 100 {
+		errs = append(errs, FieldError{Field: "name", Message: "名前は100文字以内で入力してください"})
+	}
+
+	return errs
+}
+
+func (s *AuthService) ValidateLoginInput(input *LoginInput) []FieldError {
+	var errs []FieldError
+
+	input.Email = strings.TrimSpace(input.Email)
+
+	if input.Email == "" {
+		errs = append(errs, FieldError{Field: "email", Message: "メールアドレスは必須です"})
+	}
+	if input.Password == "" {
+		errs = append(errs, FieldError{Field: "password", Message: "パスワードは必須です"})
+	}
+
+	return errs
+}
+
+type FieldError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+func (s *AuthService) Signup(ctx context.Context, input *SignupInput) (*AuthResult, error) {
+	_, err := s.queries.GetUserByEmail(ctx, input.Email)
+	if err == nil {
+		return nil, ErrEmailAlreadyExists
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, err
+	}
+
+	hash, err := auth.HashPassword(input.Password)
+	if err != nil {
+		return nil, err
+	}
+
+	user, err := s.queries.CreateUser(ctx, database.CreateUserParams{
+		Email:               input.Email,
+		PasswordHash:        hash,
+		Name:                input.Name,
+		LowStockThreshold:  100,
+		NotificationEnabled: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	userID, err := uuidFromPgtype(user.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	tokens, err := s.jwtManager.GenerateTokenPair(userID, user.Email)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AuthResult{
+		User:         toUserResponse(user),
+		AccessToken:  tokens.AccessToken,
+		RefreshToken: tokens.RefreshToken,
+	}, nil
+}
+
+func (s *AuthService) Login(ctx context.Context, input *LoginInput) (*AuthResult, error) {
+	user, err := s.queries.GetUserByEmail(ctx, input.Email)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrInvalidCredentials
+		}
+		return nil, err
+	}
+
+	if err := auth.CheckPassword(user.PasswordHash, input.Password); err != nil {
+		return nil, ErrInvalidCredentials
+	}
+
+	userID, err := uuidFromPgtype(user.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	tokens, err := s.jwtManager.GenerateTokenPair(userID, user.Email)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AuthResult{
+		User:         toUserResponse(user),
+		AccessToken:  tokens.AccessToken,
+		RefreshToken: tokens.RefreshToken,
+	}, nil
+}
+
+type RefreshResult struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+func (s *AuthService) Refresh(ctx context.Context, refreshToken string) (*RefreshResult, error) {
+	claims, err := s.jwtManager.ValidateToken(refreshToken)
+	if err != nil {
+		return nil, auth.ErrInvalidToken
+	}
+
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		return nil, auth.ErrInvalidToken
+	}
+
+	pgID := pgtype.UUID{Bytes: userID, Valid: true}
+	user, err := s.queries.GetUserByID(ctx, pgID)
+	if err != nil {
+		return nil, auth.ErrInvalidToken
+	}
+
+	uid, err := uuidFromPgtype(user.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	tokens, err := s.jwtManager.GenerateTokenPair(uid, user.Email)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RefreshResult{
+		AccessToken:  tokens.AccessToken,
+		RefreshToken: tokens.RefreshToken,
+	}, nil
+}
+
+func (s *AuthService) GetMe(ctx context.Context, userID uuid.UUID) (*UserResponse, error) {
+	pgID := pgtype.UUID{Bytes: userID, Valid: true}
+	user, err := s.queries.GetUserByID(ctx, pgID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, errors.New("user not found")
+		}
+		return nil, err
+	}
+	return toUserResponse(user), nil
+}
+
+func toUserResponse(user database.User) *UserResponse {
+	resp := &UserResponse{
+		Email:               user.Email,
+		Name:                user.Name,
+		LowStockThreshold:  user.LowStockThreshold,
+		NotificationEnabled: user.NotificationEnabled,
+	}
+	if user.ID.Valid {
+		resp.ID = uuid.UUID(user.ID.Bytes)
+	}
+	if user.CreatedAt.Valid {
+		resp.CreatedAt = user.CreatedAt.Time.Format("2006-01-02T15:04:05Z")
+	}
+	if user.UpdatedAt.Valid {
+		resp.UpdatedAt = user.UpdatedAt.Time.Format("2006-01-02T15:04:05Z")
+	}
+	return resp
+}
+
+func uuidFromPgtype(id pgtype.UUID) (uuid.UUID, error) {
+	if !id.Valid {
+		return uuid.Nil, errors.New("invalid UUID")
+	}
+	return uuid.UUID(id.Bytes), nil
+}


### PR DESCRIPTION
## Summary
- JWT認証基盤を実装（アクセストークン1h、リフレッシュトークン7d）
- 4エンドポイント: signup, login, refresh, me
- bcryptパスワードハッシュ、Bearerトークン認証ミドルウェア
- バリデーション、エラーハンドリング（409 Conflict, 401 Unauthorized等）

## Test plan
- [x] `go build ./...` コンパイル成功
- [x] POST /api/v1/auth/signup → 201 + user + tokens
- [x] POST /api/v1/auth/login → 200 + user + tokens
- [x] GET /api/v1/auth/me → 200 + user info (Bearer token)
- [x] POST /api/v1/auth/refresh → 200 + new token pair
- [x] 重複メール → 409 CONFLICT
- [x] 不正パスワード → 401 UNAUTHORIZED
- [x] バリデーションエラー → 400 + field details

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)