### PR TITLE
feat(backend): コーヒー豆CRUD API実装

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -49,6 +49,8 @@ func main() {
 	jwtManager := auth.NewJWTManager(cfg.JWTSecret)
 	authService := services.NewAuthService(queries, jwtManager)
 	authHandler := handlers.NewAuthHandler(authService)
+	coffeeBeansService := services.NewCoffeeBeansService(queries)
+	coffeeBeansHandler := handlers.NewCoffeeBeansHandler(coffeeBeansService)
 
 	r := chi.NewRouter()
 	r.Use(chimiddleware.RequestID)
@@ -75,6 +77,17 @@ func main() {
 			r.Group(func(r chi.Router) {
 				r.Use(middleware.Auth(jwtManager))
 				r.Get("/me", authHandler.GetMe)
+			})
+		})
+
+		r.Group(func(r chi.Router) {
+			r.Use(middleware.Auth(jwtManager))
+			r.Route("/coffee-beans", func(r chi.Router) {
+				r.Get("/", coffeeBeansHandler.List)
+				r.Post("/", coffeeBeansHandler.Create)
+				r.Get("/{id}", coffeeBeansHandler.Get)
+				r.Put("/{id}", coffeeBeansHandler.Update)
+				r.Delete("/{id}", coffeeBeansHandler.Delete)
 			})
 		})
 	})

--- a/backend/internal/api/handlers/coffee_beans_handler.go
+++ b/backend/internal/api/handlers/coffee_beans_handler.go
@@ -1,0 +1,195 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/api"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/api/middleware"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/services"
+)
+
+type CoffeeBeansHandler struct {
+	service *services.CoffeeBeansService
+}
+
+func NewCoffeeBeansHandler(service *services.CoffeeBeansService) *CoffeeBeansHandler {
+	return &CoffeeBeansHandler{service: service}
+}
+
+type createBeanRequest struct {
+	Name         string  `json:"name"`
+	Origin       *string `json:"origin"`
+	RoastLevel   *string `json:"roast_level"`
+	CurrentStock int32   `json:"current_stock"`
+	Notes        *string `json:"notes"`
+}
+
+type updateBeanRequest struct {
+	Name         *string `json:"name"`
+	Origin       *string `json:"origin"`
+	RoastLevel   *string `json:"roast_level"`
+	CurrentStock *int32  `json:"current_stock"`
+	Notes        *string `json:"notes"`
+}
+
+func (h *CoffeeBeansHandler) List(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.GetUserID(r.Context())
+	if !ok {
+		api.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "認証が必要です")
+		return
+	}
+
+	limit := int32(parseQueryInt(r, "limit", 20))
+	offset := int32(parseQueryInt(r, "offset", 0))
+
+	result, err := h.service.List(r.Context(), userID, limit, offset)
+	if err != nil {
+		api.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "サーバーエラーが発生しました")
+		return
+	}
+
+	api.WriteSuccess(w, http.StatusOK, result)
+}
+
+func (h *CoffeeBeansHandler) Create(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.GetUserID(r.Context())
+	if !ok {
+		api.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "認証が必要です")
+		return
+	}
+
+	var req createBeanRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		api.WriteError(w, http.StatusBadRequest, "BAD_REQUEST", "リクエストの形式が不正です")
+		return
+	}
+
+	input := &services.CreateBeanInput{
+		Name:         req.Name,
+		Origin:       req.Origin,
+		RoastLevel:   req.RoastLevel,
+		CurrentStock: req.CurrentStock,
+		Notes:        req.Notes,
+	}
+
+	if errs := h.service.ValidateCreateInput(input); len(errs) > 0 {
+		api.WriteValidationError(w, toAPIFieldErrors(errs))
+		return
+	}
+
+	bean, err := h.service.Create(r.Context(), userID, input)
+	if err != nil {
+		api.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "サーバーエラーが発生しました")
+		return
+	}
+
+	api.WriteSuccess(w, http.StatusCreated, bean)
+}
+
+func (h *CoffeeBeansHandler) Get(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.GetUserID(r.Context())
+	if !ok {
+		api.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "認証が必要です")
+		return
+	}
+
+	beanID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		api.WriteError(w, http.StatusBadRequest, "BAD_REQUEST", "不正なIDです")
+		return
+	}
+
+	bean, err := h.service.GetByID(r.Context(), userID, beanID)
+	if err != nil {
+		handleBeanError(w, err)
+		return
+	}
+
+	api.WriteSuccess(w, http.StatusOK, bean)
+}
+
+func (h *CoffeeBeansHandler) Update(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.GetUserID(r.Context())
+	if !ok {
+		api.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "認証が必要です")
+		return
+	}
+
+	beanID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		api.WriteError(w, http.StatusBadRequest, "BAD_REQUEST", "不正なIDです")
+		return
+	}
+
+	var req updateBeanRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		api.WriteError(w, http.StatusBadRequest, "BAD_REQUEST", "リクエストの形式が不正です")
+		return
+	}
+
+	input := &services.UpdateBeanInput{
+		Name:         req.Name,
+		Origin:       req.Origin,
+		RoastLevel:   req.RoastLevel,
+		CurrentStock: req.CurrentStock,
+		Notes:        req.Notes,
+	}
+
+	bean, err := h.service.Update(r.Context(), userID, beanID, input)
+	if err != nil {
+		handleBeanError(w, err)
+		return
+	}
+
+	api.WriteSuccess(w, http.StatusOK, bean)
+}
+
+func (h *CoffeeBeansHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.GetUserID(r.Context())
+	if !ok {
+		api.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "認証が必要です")
+		return
+	}
+
+	beanID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		api.WriteError(w, http.StatusBadRequest, "BAD_REQUEST", "不正なIDです")
+		return
+	}
+
+	if err := h.service.Delete(r.Context(), userID, beanID); err != nil {
+		handleBeanError(w, err)
+		return
+	}
+
+	api.WriteSuccess(w, http.StatusOK, map[string]string{"message": "コーヒー豆を削除しました"})
+}
+
+func handleBeanError(w http.ResponseWriter, err error) {
+	if errors.Is(err, services.ErrBeanNotFound) {
+		api.WriteError(w, http.StatusNotFound, "BEAN_NOT_FOUND", "コーヒー豆が見つかりません")
+		return
+	}
+	if errors.Is(err, services.ErrForbidden) {
+		api.WriteError(w, http.StatusForbidden, "FORBIDDEN", "このリソースにアクセスする権限がありません")
+		return
+	}
+	api.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "サーバーエラーが発生しました")
+}
+
+func parseQueryInt(r *http.Request, key string, defaultVal int) int {
+	v := r.URL.Query().Get(key)
+	if v == "" {
+		return defaultVal
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return defaultVal
+	}
+	return n
+}

--- a/backend/internal/services/coffee_beans_service.go
+++ b/backend/internal/services/coffee_beans_service.go
@@ -1,0 +1,235 @@
+package services
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/database"
+)
+
+var (
+	ErrBeanNotFound = errors.New("coffee bean not found")
+	ErrForbidden    = errors.New("forbidden")
+)
+
+type CoffeeBeansService struct {
+	queries *database.Queries
+}
+
+func NewCoffeeBeansService(queries *database.Queries) *CoffeeBeansService {
+	return &CoffeeBeansService{queries: queries}
+}
+
+type CoffeeBeanResponse struct {
+	ID           uuid.UUID `json:"id"`
+	Name         string    `json:"name"`
+	Origin       *string   `json:"origin,omitempty"`
+	RoastLevel   *string   `json:"roast_level,omitempty"`
+	CurrentStock int32     `json:"current_stock"`
+	Notes        *string   `json:"notes,omitempty"`
+	CreatedAt    string    `json:"created_at"`
+	UpdatedAt    string    `json:"updated_at"`
+}
+
+type ListBeansResult struct {
+	Beans      []CoffeeBeanResponse `json:"beans"`
+	Pagination PaginationResponse   `json:"pagination"`
+}
+
+type PaginationResponse struct {
+	Total   int64 `json:"total"`
+	Limit   int32 `json:"limit"`
+	Offset  int32 `json:"offset"`
+	HasMore bool  `json:"has_more"`
+}
+
+type CreateBeanInput struct {
+	Name         string
+	Origin       *string
+	RoastLevel   *string
+	CurrentStock int32
+	Notes        *string
+}
+
+type UpdateBeanInput struct {
+	Name         *string
+	Origin       *string
+	RoastLevel   *string
+	CurrentStock *int32
+	Notes        *string
+}
+
+func (s *CoffeeBeansService) ValidateCreateInput(input *CreateBeanInput) []FieldError {
+	var errs []FieldError
+
+	if input.Name == "" {
+		errs = append(errs, FieldError{Field: "name", Message: "名前は必須です"})
+	} else if len(input.Name) > 200 {
+		errs = append(errs, FieldError{Field: "name", Message: "名前は200文字以内で入力してください"})
+	}
+
+	if input.CurrentStock < 0 {
+		errs = append(errs, FieldError{Field: "current_stock", Message: "在庫数は0以上で入力してください"})
+	} else if input.CurrentStock > 50000 {
+		errs = append(errs, FieldError{Field: "current_stock", Message: "在庫数は50000以下で入力してください"})
+	}
+
+	return errs
+}
+
+func (s *CoffeeBeansService) List(ctx context.Context, userID uuid.UUID, limit, offset int32) (*ListBeansResult, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	pgUserID := pgtype.UUID{Bytes: userID, Valid: true}
+
+	total, err := s.queries.CountCoffeeBeansByUserID(ctx, pgUserID)
+	if err != nil {
+		return nil, err
+	}
+
+	beans, err := s.queries.ListCoffeeBeansByUserID(ctx, database.ListCoffeeBeansByUserIDParams{
+		UserID: pgUserID,
+		Limit:  limit,
+		Offset: offset,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]CoffeeBeanResponse, len(beans))
+	for i, b := range beans {
+		result[i] = toCoffeeBeanResponse(b)
+	}
+
+	return &ListBeansResult{
+		Beans: result,
+		Pagination: PaginationResponse{
+			Total:   total,
+			Limit:   limit,
+			Offset:  offset,
+			HasMore: int64(offset+limit) < total,
+		},
+	}, nil
+}
+
+func (s *CoffeeBeansService) Create(ctx context.Context, userID uuid.UUID, input *CreateBeanInput) (*CoffeeBeanResponse, error) {
+	bean, err := s.queries.CreateCoffeeBean(ctx, database.CreateCoffeeBeanParams{
+		UserID:       pgtype.UUID{Bytes: userID, Valid: true},
+		Name:         input.Name,
+		Origin:       toPgText(input.Origin),
+		RoastLevel:   toPgText(input.RoastLevel),
+		CurrentStock: input.CurrentStock,
+		Notes:        toPgText(input.Notes),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	resp := toCoffeeBeanResponse(bean)
+	return &resp, nil
+}
+
+func (s *CoffeeBeansService) GetByID(ctx context.Context, userID uuid.UUID, beanID uuid.UUID) (*CoffeeBeanResponse, error) {
+	bean, err := s.queries.GetCoffeeBeanByID(ctx, pgtype.UUID{Bytes: beanID, Valid: true})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrBeanNotFound
+		}
+		return nil, err
+	}
+
+	if bean.UserID.Valid && uuid.UUID(bean.UserID.Bytes) != userID {
+		return nil, ErrForbidden
+	}
+
+	resp := toCoffeeBeanResponse(bean)
+	return &resp, nil
+}
+
+func (s *CoffeeBeansService) Update(ctx context.Context, userID uuid.UUID, beanID uuid.UUID, input *UpdateBeanInput) (*CoffeeBeanResponse, error) {
+	// Verify ownership first
+	_, err := s.GetByID(ctx, userID, beanID)
+	if err != nil {
+		return nil, err
+	}
+
+	bean, err := s.queries.UpdateCoffeeBean(ctx, database.UpdateCoffeeBeanParams{
+		ID:           pgtype.UUID{Bytes: beanID, Valid: true},
+		UserID:       pgtype.UUID{Bytes: userID, Valid: true},
+		Name:         toPgText(input.Name),
+		Origin:       toPgText(input.Origin),
+		RoastLevel:   toPgText(input.RoastLevel),
+		CurrentStock: toPgInt4(input.CurrentStock),
+		Notes:        toPgText(input.Notes),
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrBeanNotFound
+		}
+		return nil, err
+	}
+
+	resp := toCoffeeBeanResponse(bean)
+	return &resp, nil
+}
+
+func (s *CoffeeBeansService) Delete(ctx context.Context, userID uuid.UUID, beanID uuid.UUID) error {
+	// Verify ownership first
+	_, err := s.GetByID(ctx, userID, beanID)
+	if err != nil {
+		return err
+	}
+
+	return s.queries.SoftDeleteCoffeeBean(ctx, database.SoftDeleteCoffeeBeanParams{
+		ID:     pgtype.UUID{Bytes: beanID, Valid: true},
+		UserID: pgtype.UUID{Bytes: userID, Valid: true},
+	})
+}
+
+func toCoffeeBeanResponse(b database.CoffeeBean) CoffeeBeanResponse {
+	resp := CoffeeBeanResponse{
+		Name:         b.Name,
+		CurrentStock: b.CurrentStock,
+	}
+	if b.ID.Valid {
+		resp.ID = uuid.UUID(b.ID.Bytes)
+	}
+	if b.Origin.Valid {
+		resp.Origin = &b.Origin.String
+	}
+	if b.RoastLevel.Valid {
+		resp.RoastLevel = &b.RoastLevel.String
+	}
+	if b.Notes.Valid {
+		resp.Notes = &b.Notes.String
+	}
+	if b.CreatedAt.Valid {
+		resp.CreatedAt = b.CreatedAt.Time.Format("2006-01-02T15:04:05Z")
+	}
+	if b.UpdatedAt.Valid {
+		resp.UpdatedAt = b.UpdatedAt.Time.Format("2006-01-02T15:04:05Z")
+	}
+	return resp
+}
+
+func toPgText(s *string) pgtype.Text {
+	if s == nil {
+		return pgtype.Text{Valid: false}
+	}
+	return pgtype.Text{String: *s, Valid: true}
+}
+
+func toPgInt4(i *int32) pgtype.Int4 {
+	if i == nil {
+		return pgtype.Int4{Valid: false}
+	}
+	return pgtype.Int4{Int32: *i, Valid: true}
+}


### PR DESCRIPTION
## Summary
- コーヒー豆の一覧・登録・詳細・更新・削除の5エンドポイントを実装
- JWT認証必須、リソース所有権検証（403 Forbidden）
- ページネーション（limit/offset + total/has_more）
- ソフトデリート対応
- バリデーション（name必須、stock範囲チェック）

## Test plan
- [x] `go build ./...` コンパイル成功
- [x] POST /api/v1/coffee-beans → 201 + bean data
- [x] GET /api/v1/coffee-beans → 200 + beans list + pagination
- [x] GET /api/v1/coffee-beans/:id → 200 + bean detail
- [x] PUT /api/v1/coffee-beans/:id → 200 + updated bean
- [x] DELETE /api/v1/coffee-beans/:id → 200 + success message
- [x] 削除済みbean取得 → 404 BEAN_NOT_FOUND

Closes #29 Closes #30 Closes #31 Closes #32 Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)