### PR TITLE
fix(backend): トランザクション整合性の改善とリポジトリテスト追加

### DIFF
--- a/backend/internal/database/querier.go
+++ b/backend/internal/database/querier.go
@@ -34,6 +34,7 @@ type Querier interface {
 	DeletePurchaseHistory(ctx context.Context, arg DeletePurchaseHistoryParams) error
 	DeleteUsageHistory(ctx context.Context, arg DeleteUsageHistoryParams) error
 	GetCoffeeBeanByID(ctx context.Context, id pgtype.UUID) (CoffeeBean, error)
+	GetCoffeeBeanByIDForUpdate(ctx context.Context, id pgtype.UUID) (CoffeeBean, error)
 	GetLatestPurchaseHistoryByCoffeeBeanID(ctx context.Context, coffeeBeanID pgtype.UUID) (PurchaseHistory, error)
 	GetPurchaseHistoriesByCoffeeBeanID(ctx context.Context, arg GetPurchaseHistoriesByCoffeeBeanIDParams) ([]PurchaseHistory, error)
 	GetPurchaseHistoryByID(ctx context.Context, id pgtype.UUID) (PurchaseHistory, error)

--- a/backend/internal/database/queries.sql.go
+++ b/backend/internal/database/queries.sql.go
@@ -286,6 +286,31 @@ func (q *Queries) GetCoffeeBeanByID(ctx context.Context, id pgtype.UUID) (Coffee
 	return i, err
 }
 
+const getCoffeeBeanByIDForUpdate = `-- name: GetCoffeeBeanByIDForUpdate :one
+SELECT id, user_id, name, origin, roast_level, roast_detail, current_stock, notes, created_at, updated_at, deleted_at FROM coffee_beans
+WHERE id = $1 AND deleted_at IS NULL
+FOR UPDATE
+`
+
+func (q *Queries) GetCoffeeBeanByIDForUpdate(ctx context.Context, id pgtype.UUID) (CoffeeBean, error) {
+	row := q.db.QueryRow(ctx, getCoffeeBeanByIDForUpdate, id)
+	var i CoffeeBean
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.Name,
+		&i.Origin,
+		&i.RoastLevel,
+		&i.RoastDetail,
+		&i.CurrentStock,
+		&i.Notes,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+	)
+	return i, err
+}
+
 const getLatestPurchaseHistoryByCoffeeBeanID = `-- name: GetLatestPurchaseHistoryByCoffeeBeanID :one
 SELECT id, coffee_bean_id, user_id, purchase_date, purchase_price, purchase_store, quantity, notes, created_at FROM purchase_history
 WHERE coffee_bean_id = $1

--- a/backend/internal/domain/coffeebean/repository.go
+++ b/backend/internal/domain/coffeebean/repository.go
@@ -8,6 +8,7 @@ import (
 
 type Repository interface {
 	GetByID(ctx context.Context, id uuid.UUID) (*CoffeeBean, error)
+	GetByIDForUpdate(ctx context.Context, id uuid.UUID) (*CoffeeBean, error)
 	ListByUserID(ctx context.Context, userID uuid.UUID, limit, offset int32) ([]*CoffeeBean, error)
 	CountByUserID(ctx context.Context, userID uuid.UUID) (int64, error)
 	Save(ctx context.Context, bean *CoffeeBean) error

--- a/backend/internal/repository/coffee_bean_repository_impl.go
+++ b/backend/internal/repository/coffee_bean_repository_impl.go
@@ -31,6 +31,17 @@ func (r *coffeeBeanRepository) GetByID(ctx context.Context, id uuid.UUID) (*coff
 	return toDomainCoffeeBean(b), nil
 }
 
+func (r *coffeeBeanRepository) GetByIDForUpdate(ctx context.Context, id uuid.UUID) (*coffeebean.CoffeeBean, error) {
+	b, err := r.queries.GetCoffeeBeanByIDForUpdate(ctx, toUUID(id))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, err
+	}
+	return toDomainCoffeeBean(b), nil
+}
+
 func (r *coffeeBeanRepository) ListByUserID(ctx context.Context, userID uuid.UUID, limit, offset int32) ([]*coffeebean.CoffeeBean, error) {
 	rows, err := r.queries.ListCoffeeBeansByUserID(ctx, database.ListCoffeeBeansByUserIDParams{
 		UserID: toUUID(userID),
@@ -87,6 +98,9 @@ func (r *coffeeBeanRepository) Update(ctx context.Context, bean *coffeebean.Coff
 		params.RoastDetail = toPgText(&s)
 	}
 	_, err := r.queries.UpdateCoffeeBean(ctx, params)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return domain.ErrNotFound
+	}
 	return err
 }
 

--- a/backend/internal/repository/coffee_bean_repository_test.go
+++ b/backend/internal/repository/coffee_bean_repository_test.go
@@ -1,0 +1,490 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+
+	domain "github.com/k3forx/CoffeeBeansStock/backend/internal/domain"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/domain/coffeebean"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/domain/user"
+)
+
+// newTestBean creates a CoffeeBean domain object for testing.
+func newTestBean(t *testing.T, userID uuid.UUID) *coffeebean.CoffeeBean {
+	t.Helper()
+	stock, _ := coffeebean.NewStock(500)
+	bean, err := coffeebean.New(userID, "Test Bean", coffeebean.RoastMedium, nil, nil, nil, stock)
+	if err != nil {
+		t.Fatalf("setup: new bean: %v", err)
+	}
+	return bean
+}
+
+// newTestBeanFull creates a CoffeeBean with all optional fields set.
+func newTestBeanFull(t *testing.T, userID uuid.UUID) *coffeebean.CoffeeBean {
+	t.Helper()
+	stock, _ := coffeebean.NewStock(1000)
+	origin := "Ethiopia"
+	notes := "fruity aroma"
+	detail := coffeebean.RoastDetailCity
+	bean, err := coffeebean.New(userID, "Full Bean", coffeebean.RoastMediumDeep, &detail, &origin, &notes, stock)
+	if err != nil {
+		t.Fatalf("setup: new full bean: %v", err)
+	}
+	return bean
+}
+
+// coffeeBeanCmpOpts returns cmp options for comparing CoffeeBean.
+func coffeeBeanCmpOpts() []cmp.Option {
+	return []cmp.Option{
+		cmp.AllowUnexported(coffeebean.CoffeeBean{}, coffeebean.Stock{}, coffeebean.RoastLevel{}, coffeebean.RoastDetail{}),
+		cmp.FilterPath(func(p cmp.Path) bool {
+			switch p.String() {
+			case "CreatedAt", "UpdatedAt", "createdAt", "updatedAt":
+				return true
+			}
+			return false
+		}, cmp.Ignore()),
+	}
+}
+
+// setupBeanRepo creates a repo and saves a user, returning both.
+func setupBeanRepo(t *testing.T) (coffeebean.Repository, uuid.UUID) {
+	t.Helper()
+	tx := newTestTx(t)
+	userRepo := NewUserRepository(tx)
+	u := user.NewAnonymousUser()
+	if err := userRepo.Save(t.Context(), u); err != nil {
+		t.Fatalf("setup: save user: %v", err)
+	}
+	return NewCoffeeBeanRepository(tx), u.ID()
+}
+
+func TestCoffeeBeanRepository_Save(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		makeBean func(t *testing.T, userID uuid.UUID) *coffeebean.CoffeeBean
+	}{
+		"saves bean with required fields only": {
+			makeBean: newTestBean,
+		},
+		"saves bean with all optional fields": {
+			makeBean: newTestBeanFull,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			repo, userID := setupBeanRepo(t)
+			bean := tt.makeBean(t, userID)
+
+			err := repo.Save(t.Context(), bean)
+
+			if err != nil {
+				t.Errorf("Save() error: %v", err)
+				return
+			}
+
+			got, err := repo.GetByID(t.Context(), bean.ID())
+			if err != nil {
+				t.Errorf("GetByID() after Save error: %v", err)
+				return
+			}
+			if diff := cmp.Diff(bean, got, coffeeBeanCmpOpts()...); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCoffeeBeanRepository_GetByID(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		setup   func(t *testing.T, repo coffeebean.Repository, userID uuid.UUID) uuid.UUID
+		wantErr error
+	}{
+		"returns bean by ID": {
+			setup: func(t *testing.T, repo coffeebean.Repository, userID uuid.UUID) uuid.UUID {
+				t.Helper()
+				bean := newTestBean(t, userID)
+				if err := repo.Save(t.Context(), bean); err != nil {
+					t.Fatalf("setup: save bean: %v", err)
+				}
+				return bean.ID()
+			},
+		},
+		"returns ErrNotFound for non-existent ID": {
+			setup: func(t *testing.T, _ coffeebean.Repository, _ uuid.UUID) uuid.UUID {
+				t.Helper()
+				return uuid.New()
+			},
+			wantErr: domain.ErrNotFound,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			repo, userID := setupBeanRepo(t)
+			targetID := tt.setup(t, repo, userID)
+
+			got, err := repo.GetByID(t.Context(), targetID)
+
+			if tt.wantErr != nil {
+				if err == nil {
+					t.Errorf("expected error %v, got nil", tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if got.ID() != targetID {
+				t.Errorf("ID = %v, want %v", got.ID(), targetID)
+			}
+		})
+	}
+}
+
+func TestCoffeeBeanRepository_GetByIDForUpdate(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		setup   func(t *testing.T, repo coffeebean.Repository, userID uuid.UUID) uuid.UUID
+		wantErr error
+	}{
+		"returns bean by ID with row lock": {
+			setup: func(t *testing.T, repo coffeebean.Repository, userID uuid.UUID) uuid.UUID {
+				t.Helper()
+				bean := newTestBean(t, userID)
+				if err := repo.Save(t.Context(), bean); err != nil {
+					t.Fatalf("setup: save bean: %v", err)
+				}
+				return bean.ID()
+			},
+		},
+		"returns ErrNotFound for non-existent ID": {
+			setup: func(t *testing.T, _ coffeebean.Repository, _ uuid.UUID) uuid.UUID {
+				t.Helper()
+				return uuid.New()
+			},
+			wantErr: domain.ErrNotFound,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			repo, userID := setupBeanRepo(t)
+			targetID := tt.setup(t, repo, userID)
+
+			got, err := repo.GetByIDForUpdate(t.Context(), targetID)
+
+			if tt.wantErr != nil {
+				if err == nil {
+					t.Errorf("expected error %v, got nil", tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if got.ID() != targetID {
+				t.Errorf("ID = %v, want %v", got.ID(), targetID)
+			}
+		})
+	}
+}
+
+func TestCoffeeBeanRepository_ListByUserID(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		seedCount int
+		limit     int32
+		offset    int32
+		wantCount int
+	}{
+		"returns all beans for user": {
+			seedCount: 3,
+			limit:     10,
+			offset:    0,
+			wantCount: 3,
+		},
+		"returns empty list when no beans": {
+			seedCount: 0,
+			limit:     10,
+			offset:    0,
+			wantCount: 0,
+		},
+		"respects limit": {
+			seedCount: 5,
+			limit:     2,
+			offset:    0,
+			wantCount: 2,
+		},
+		"respects offset": {
+			seedCount: 5,
+			limit:     10,
+			offset:    3,
+			wantCount: 2,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			repo, userID := setupBeanRepo(t)
+			for i := 0; i < tt.seedCount; i++ {
+				stock, _ := coffeebean.NewStock(int32(100 * (i + 1)))
+				bean, err := coffeebean.New(userID, "Bean "+string(rune('A'+i)), coffeebean.RoastMedium, nil, nil, nil, stock)
+				if err != nil {
+					t.Fatalf("setup: new bean: %v", err)
+				}
+				if err := repo.Save(t.Context(), bean); err != nil {
+					t.Fatalf("setup: save bean: %v", err)
+				}
+			}
+
+			got, err := repo.ListByUserID(t.Context(), userID, tt.limit, tt.offset)
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if len(got) != tt.wantCount {
+				t.Errorf("count = %d, want %d", len(got), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestCoffeeBeanRepository_CountByUserID(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		seedCount int
+		wantCount int64
+	}{
+		"counts beans for user": {
+			seedCount: 3,
+			wantCount: 3,
+		},
+		"returns zero when no beans": {
+			seedCount: 0,
+			wantCount: 0,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			repo, userID := setupBeanRepo(t)
+			for i := 0; i < tt.seedCount; i++ {
+				stock, _ := coffeebean.NewStock(100)
+				bean, err := coffeebean.New(userID, "Bean "+string(rune('A'+i)), coffeebean.RoastMedium, nil, nil, nil, stock)
+				if err != nil {
+					t.Fatalf("setup: new bean: %v", err)
+				}
+				if err := repo.Save(t.Context(), bean); err != nil {
+					t.Fatalf("setup: save bean: %v", err)
+				}
+			}
+
+			got, err := repo.CountByUserID(t.Context(), userID)
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if got != tt.wantCount {
+				t.Errorf("count = %d, want %d", got, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestCoffeeBeanRepository_Update(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		setup   func(t *testing.T, repo coffeebean.Repository, userID uuid.UUID) *coffeebean.CoffeeBean
+		wantErr error
+	}{
+		"updates bean fields": {
+			setup: func(t *testing.T, repo coffeebean.Repository, userID uuid.UUID) *coffeebean.CoffeeBean {
+				t.Helper()
+				bean := newTestBean(t, userID)
+				if err := repo.Save(t.Context(), bean); err != nil {
+					t.Fatalf("setup: save bean: %v", err)
+				}
+				newName := "Updated Bean"
+				newOrigin := "Colombia"
+				newLevel := coffeebean.RoastDeep
+				newDetail := coffeebean.RoastDetailFrench
+				newNotes := "bold flavor"
+				newStock, _ := coffeebean.NewStock(999)
+				if err := bean.Update(&newName, &newOrigin, &newLevel, &newDetail, &newNotes, &newStock); err != nil {
+					t.Fatalf("setup: update domain: %v", err)
+				}
+				return bean
+			},
+		},
+		"returns ErrNotFound for non-existent bean": {
+			setup: func(t *testing.T, _ coffeebean.Repository, userID uuid.UUID) *coffeebean.CoffeeBean {
+				t.Helper()
+				return newTestBean(t, userID)
+			},
+			wantErr: domain.ErrNotFound,
+		},
+		"returns ErrNotFound when user does not own the bean": {
+			setup: func(t *testing.T, repo coffeebean.Repository, userID uuid.UUID) *coffeebean.CoffeeBean {
+				t.Helper()
+				bean := newTestBean(t, userID)
+				if err := repo.Save(t.Context(), bean); err != nil {
+					t.Fatalf("setup: save bean: %v", err)
+				}
+				// Reconstruct with a different userID to simulate wrong owner
+				otherUserID := uuid.New()
+				return coffeebean.Reconstruct(
+					bean.ID(), otherUserID, bean.Name(), bean.Origin(),
+					bean.RoastLevel(), bean.RoastDetail(), bean.CurrentStock(),
+					bean.Notes(), bean.CreatedAt(), bean.UpdatedAt(),
+				)
+			},
+			wantErr: domain.ErrNotFound,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			repo, userID := setupBeanRepo(t)
+			bean := tt.setup(t, repo, userID)
+
+			err := repo.Update(t.Context(), bean)
+
+			if tt.wantErr != nil {
+				if err == nil {
+					t.Errorf("expected error %v, got nil", tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			got, err := repo.GetByID(t.Context(), bean.ID())
+			if err != nil {
+				t.Errorf("GetByID() after Update error: %v", err)
+				return
+			}
+			if diff := cmp.Diff(bean, got, coffeeBeanCmpOpts()...); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCoffeeBeanRepository_SoftDelete(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		setup   func(t *testing.T, repo coffeebean.Repository, userID uuid.UUID) (beanID uuid.UUID, deleteUserID uuid.UUID)
+		wantErr error
+	}{
+		"soft deletes a bean": {
+			setup: func(t *testing.T, repo coffeebean.Repository, userID uuid.UUID) (uuid.UUID, uuid.UUID) {
+				t.Helper()
+				bean := newTestBean(t, userID)
+				if err := repo.Save(t.Context(), bean); err != nil {
+					t.Fatalf("setup: save bean: %v", err)
+				}
+				return bean.ID(), userID
+			},
+		},
+		"does not error when bean does not exist": {
+			setup: func(t *testing.T, _ coffeebean.Repository, userID uuid.UUID) (uuid.UUID, uuid.UUID) {
+				t.Helper()
+				return uuid.New(), userID
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			repo, userID := setupBeanRepo(t)
+			beanID, deleteUserID := tt.setup(t, repo, userID)
+
+			err := repo.SoftDelete(t.Context(), beanID, deleteUserID)
+
+			if tt.wantErr != nil {
+				if err == nil {
+					t.Errorf("expected error %v, got nil", tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			// Verify the bean is no longer found
+			_, err = repo.GetByID(t.Context(), beanID)
+			if err != domain.ErrNotFound {
+				t.Errorf("GetByID() after SoftDelete: expected ErrNotFound, got %v", err)
+			}
+		})
+	}
+}
+
+func TestCoffeeBeanRepository_CountByUserID_excludes_deleted(t *testing.T) {
+	t.Parallel()
+
+	repo, userID := setupBeanRepo(t)
+
+	// Create 3 beans, soft-delete 1
+	var deleteID uuid.UUID
+	for i := 0; i < 3; i++ {
+		stock, _ := coffeebean.NewStock(100)
+		bean, err := coffeebean.New(userID, "Bean "+string(rune('A'+i)), coffeebean.RoastMedium, nil, nil, nil, stock)
+		if err != nil {
+			t.Fatalf("setup: new bean: %v", err)
+		}
+		if err := repo.Save(t.Context(), bean); err != nil {
+			t.Fatalf("setup: save bean: %v", err)
+		}
+		if i == 0 {
+			deleteID = bean.ID()
+		}
+	}
+	if err := repo.SoftDelete(t.Context(), deleteID, userID); err != nil {
+		t.Fatalf("setup: soft delete: %v", err)
+	}
+
+	got, err := repo.CountByUserID(t.Context(), userID)
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		return
+	}
+	if got != 2 {
+		t.Errorf("count = %d, want 2 (one bean was soft-deleted)", got)
+	}
+}

--- a/backend/internal/usecase/auth_service.go
+++ b/backend/internal/usecase/auth_service.go
@@ -32,12 +32,13 @@ type AuthResult struct {
 // RegisterAnonymous creates a new anonymous user and returns tokens.
 func (s *AuthService) RegisterAnonymous(ctx context.Context) (*AuthResult, error) {
 	u := user.NewAnonymousUser()
-	if err := s.userRepo.Save(ctx, u); err != nil {
-		return nil, err
-	}
 
 	tokens, err := s.tokens.GenerateTokenPair(u.ID())
 	if err != nil {
+		return nil, err
+	}
+
+	if err := s.userRepo.Save(ctx, u); err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/usecase/auth_service_test.go
+++ b/backend/internal/usecase/auth_service_test.go
@@ -39,21 +39,24 @@ func TestAuthService_RegisterAnonymous(t *testing.T) {
 				return usecase.NewAuthService(ur, tm)
 			},
 		},
-		"userRepo.Saveのエラーが伝播する": {
-			setup: func(ctrl *gomock.Controller) *usecase.AuthService {
-				ur := mock.NewMockUserRepository(ctrl)
-				tm := mock.NewMockTokenManager(ctrl)
-				ur.EXPECT().Save(gomock.Any(), gomock.Any()).Return(errors.New("db error"))
-				return usecase.NewAuthService(ur, tm)
-			},
-			wantErr: true,
-		},
 		"GenerateTokenPairのエラーが伝播する": {
 			setup: func(ctrl *gomock.Controller) *usecase.AuthService {
 				ur := mock.NewMockUserRepository(ctrl)
 				tm := mock.NewMockTokenManager(ctrl)
-				ur.EXPECT().Save(gomock.Any(), gomock.Any()).Return(nil)
 				tm.EXPECT().GenerateTokenPair(gomock.Any()).Return(nil, errors.New("token error"))
+				return usecase.NewAuthService(ur, tm)
+			},
+			wantErr: true,
+		},
+		"userRepo.Saveのエラーが伝播する": {
+			setup: func(ctrl *gomock.Controller) *usecase.AuthService {
+				ur := mock.NewMockUserRepository(ctrl)
+				tm := mock.NewMockTokenManager(ctrl)
+				tm.EXPECT().GenerateTokenPair(gomock.Any()).Return(&domainauth.TokenPair{
+					AccessToken:  "access-token",
+					RefreshToken: "refresh-token",
+				}, nil)
+				ur.EXPECT().Save(gomock.Any(), gomock.Any()).Return(errors.New("db error"))
 				return usecase.NewAuthService(ur, tm)
 			},
 			wantErr: true,

--- a/backend/internal/usecase/coffee_beans_service.go
+++ b/backend/internal/usecase/coffee_beans_service.go
@@ -168,14 +168,6 @@ func (s *CoffeeBeansService) GetByID(ctx context.Context, in GetBeanByIDInput) (
 
 // Update updates a coffee bean, verifying ownership.
 func (s *CoffeeBeansService) Update(ctx context.Context, in UpdateBeanInput) (*UpdateBeanOutput, error) {
-	bean, err := s.beanRepo.GetByID(ctx, in.BeanID)
-	if err != nil {
-		return nil, err
-	}
-	if !bean.IsOwnedBy(in.UserID) {
-		return nil, domain.ErrForbidden
-	}
-
 	var rl *coffeebean.RoastLevel
 	if in.RoastLevel != nil {
 		r, err := coffeebean.NewRoastLevel(*in.RoastLevel)
@@ -201,23 +193,40 @@ func (s *CoffeeBeansService) Update(ctx context.Context, in UpdateBeanInput) (*U
 		st = &stk
 	}
 
-	if err := bean.Update(in.Name, in.Origin, rl, rd, in.Notes, st); err != nil {
+	var result *UpdateBeanOutput
+	err := s.uow.RunInTx(ctx, func(store unitofwork.Store) error {
+		bean, err := store.CoffeeBeanRepo().GetByIDForUpdate(ctx, in.BeanID)
+		if err != nil {
+			return err
+		}
+		if !bean.IsOwnedBy(in.UserID) {
+			return domain.ErrForbidden
+		}
+		if err := bean.Update(in.Name, in.Origin, rl, rd, in.Notes, st); err != nil {
+			return err
+		}
+		if err := store.CoffeeBeanRepo().Update(ctx, bean); err != nil {
+			return err
+		}
+		result = &UpdateBeanOutput{Bean: bean}
+		return nil
+	})
+	if err != nil {
 		return nil, err
 	}
-	if err := s.beanRepo.Update(ctx, bean); err != nil {
-		return nil, err
-	}
-	return &UpdateBeanOutput{Bean: bean}, nil
+	return result, nil
 }
 
 // Delete soft-deletes a coffee bean, verifying ownership.
 func (s *CoffeeBeansService) Delete(ctx context.Context, in DeleteBeanInput) error {
-	bean, err := s.beanRepo.GetByID(ctx, in.BeanID)
-	if err != nil {
-		return err
-	}
-	if !bean.IsOwnedBy(in.UserID) {
-		return domain.ErrForbidden
-	}
-	return s.beanRepo.SoftDelete(ctx, in.BeanID, in.UserID)
+	return s.uow.RunInTx(ctx, func(store unitofwork.Store) error {
+		bean, err := store.CoffeeBeanRepo().GetByIDForUpdate(ctx, in.BeanID)
+		if err != nil {
+			return err
+		}
+		if !bean.IsOwnedBy(in.UserID) {
+			return domain.ErrForbidden
+		}
+		return store.CoffeeBeanRepo().SoftDelete(ctx, in.BeanID, in.UserID)
+	})
 }

--- a/backend/internal/usecase/coffee_beans_service_test.go
+++ b/backend/internal/usecase/coffee_beans_service_test.go
@@ -1,6 +1,7 @@
 package usecase_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 
 	domain "github.com/k3forx/CoffeeBeansStock/backend/internal/domain"
 	"github.com/k3forx/CoffeeBeansStock/backend/internal/domain/coffeebean"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/domain/unitofwork"
 	"github.com/k3forx/CoffeeBeansStock/backend/internal/usecase"
 	"github.com/k3forx/CoffeeBeansStock/backend/internal/usecase/mock"
 )
@@ -342,6 +344,17 @@ func TestCoffeeBeansService_GetByID(t *testing.T) {
 	}
 }
 
+// fakeRunInTx returns a mock UoW whose RunInTx executes the callback with the given store.
+func fakeRunInTx(ctrl *gomock.Controller, store *mock.MockStore) *mock.MockUnitOfWork {
+	uow := mock.NewMockUnitOfWork(ctrl)
+	uow.EXPECT().RunInTx(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, fn func(unitofwork.Store) error) error {
+			return fn(store)
+		},
+	)
+	return uow
+}
+
 func TestCoffeeBeansService_Update(t *testing.T) {
 	t.Parallel()
 
@@ -355,11 +368,22 @@ func TestCoffeeBeansService_Update(t *testing.T) {
 		wantValidation bool
 		wantErr        error
 	}{
+		"無効なRoastLevelはValidationErrorを返す（トランザクション前に失敗）": {
+			setup: func(ctrl *gomock.Controller) *usecase.CoffeeBeansService {
+				r := mock.NewMockCoffeeBeanRepository(ctrl)
+				return usecase.NewCoffeeBeansService(r, nil)
+			},
+			in:             usecase.UpdateBeanInput{UserID: userID, BeanID: beanID, RoastLevel: ptr("invalid")},
+			wantValidation: true,
+		},
 		"ErrNotFoundが伝播する": {
 			setup: func(ctrl *gomock.Controller) *usecase.CoffeeBeansService {
 				r := mock.NewMockCoffeeBeanRepository(ctrl)
-				r.EXPECT().GetByID(gomock.Any(), beanID).Return(nil, domain.ErrNotFound)
-				return usecase.NewCoffeeBeansService(r, nil)
+				store := mock.NewMockStore(ctrl)
+				store.EXPECT().CoffeeBeanRepo().Return(r).AnyTimes()
+				r.EXPECT().GetByIDForUpdate(gomock.Any(), beanID).Return(nil, domain.ErrNotFound)
+				uow := fakeRunInTx(ctrl, store)
+				return usecase.NewCoffeeBeansService(r, uow)
 			},
 			in:      usecase.UpdateBeanInput{UserID: userID, BeanID: beanID},
 			wantErr: domain.ErrNotFound,
@@ -372,25 +396,14 @@ func TestCoffeeBeansService_Update(t *testing.T) {
 					coffeebean.RoastShallow, nil, coffeebean.ReconstructStock(100), nil,
 					time.Now(), time.Now(),
 				)
-				r.EXPECT().GetByID(gomock.Any(), beanID).Return(testBean, nil)
-				return usecase.NewCoffeeBeansService(r, nil)
+				store := mock.NewMockStore(ctrl)
+				store.EXPECT().CoffeeBeanRepo().Return(r).AnyTimes()
+				r.EXPECT().GetByIDForUpdate(gomock.Any(), beanID).Return(testBean, nil)
+				uow := fakeRunInTx(ctrl, store)
+				return usecase.NewCoffeeBeansService(r, uow)
 			},
 			in:      usecase.UpdateBeanInput{UserID: otherUserID, BeanID: beanID},
 			wantErr: domain.ErrForbidden,
-		},
-		"無効なRoastLevelはValidationErrorを返す": {
-			setup: func(ctrl *gomock.Controller) *usecase.CoffeeBeansService {
-				r := mock.NewMockCoffeeBeanRepository(ctrl)
-				testBean := coffeebean.Reconstruct(
-					beanID, userID, "Test Bean", nil,
-					coffeebean.RoastShallow, nil, coffeebean.ReconstructStock(100), nil,
-					time.Now(), time.Now(),
-				)
-				r.EXPECT().GetByID(gomock.Any(), beanID).Return(testBean, nil)
-				return usecase.NewCoffeeBeansService(r, nil)
-			},
-			in:             usecase.UpdateBeanInput{UserID: userID, BeanID: beanID, RoastLevel: ptr("invalid")},
-			wantValidation: true,
 		},
 		"Repo.Updateのエラーが伝播する": {
 			setup: func(ctrl *gomock.Controller) *usecase.CoffeeBeansService {
@@ -400,9 +413,12 @@ func TestCoffeeBeansService_Update(t *testing.T) {
 					coffeebean.RoastShallow, nil, coffeebean.ReconstructStock(100), nil,
 					time.Now(), time.Now(),
 				)
-				r.EXPECT().GetByID(gomock.Any(), beanID).Return(testBean, nil)
+				store := mock.NewMockStore(ctrl)
+				store.EXPECT().CoffeeBeanRepo().Return(r).AnyTimes()
+				r.EXPECT().GetByIDForUpdate(gomock.Any(), beanID).Return(testBean, nil)
 				r.EXPECT().Update(gomock.Any(), gomock.Any()).Return(errors.New("db error"))
-				return usecase.NewCoffeeBeansService(r, nil)
+				uow := fakeRunInTx(ctrl, store)
+				return usecase.NewCoffeeBeansService(r, uow)
 			},
 			in: usecase.UpdateBeanInput{UserID: userID, BeanID: beanID, Name: ptr("Updated")},
 		},
@@ -414,9 +430,12 @@ func TestCoffeeBeansService_Update(t *testing.T) {
 					coffeebean.RoastShallow, nil, coffeebean.ReconstructStock(100), nil,
 					time.Now(), time.Now(),
 				)
-				r.EXPECT().GetByID(gomock.Any(), beanID).Return(testBean, nil)
+				store := mock.NewMockStore(ctrl)
+				store.EXPECT().CoffeeBeanRepo().Return(r).AnyTimes()
+				r.EXPECT().GetByIDForUpdate(gomock.Any(), beanID).Return(testBean, nil)
 				r.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
-				return usecase.NewCoffeeBeansService(r, nil)
+				uow := fakeRunInTx(ctrl, store)
+				return usecase.NewCoffeeBeansService(r, uow)
 			},
 			in: usecase.UpdateBeanInput{UserID: userID, BeanID: beanID, Name: ptr("New Name")},
 		},
@@ -482,17 +501,23 @@ func TestCoffeeBeansService_Delete(t *testing.T) {
 		"正常に削除できる": {
 			setup: func(ctrl *gomock.Controller) *usecase.CoffeeBeansService {
 				r := mock.NewMockCoffeeBeanRepository(ctrl)
-				r.EXPECT().GetByID(gomock.Any(), beanID).Return(testBean, nil)
+				store := mock.NewMockStore(ctrl)
+				store.EXPECT().CoffeeBeanRepo().Return(r).AnyTimes()
+				r.EXPECT().GetByIDForUpdate(gomock.Any(), beanID).Return(testBean, nil)
 				r.EXPECT().SoftDelete(gomock.Any(), beanID, userID).Return(nil)
-				return usecase.NewCoffeeBeansService(r, nil)
+				uow := fakeRunInTx(ctrl, store)
+				return usecase.NewCoffeeBeansService(r, uow)
 			},
 			in: usecase.DeleteBeanInput{UserID: userID, BeanID: beanID},
 		},
 		"ErrNotFoundが伝播する": {
 			setup: func(ctrl *gomock.Controller) *usecase.CoffeeBeansService {
 				r := mock.NewMockCoffeeBeanRepository(ctrl)
-				r.EXPECT().GetByID(gomock.Any(), beanID).Return(nil, domain.ErrNotFound)
-				return usecase.NewCoffeeBeansService(r, nil)
+				store := mock.NewMockStore(ctrl)
+				store.EXPECT().CoffeeBeanRepo().Return(r).AnyTimes()
+				r.EXPECT().GetByIDForUpdate(gomock.Any(), beanID).Return(nil, domain.ErrNotFound)
+				uow := fakeRunInTx(ctrl, store)
+				return usecase.NewCoffeeBeansService(r, uow)
 			},
 			in:      usecase.DeleteBeanInput{UserID: userID, BeanID: beanID},
 			wantErr: domain.ErrNotFound,
@@ -500,8 +525,11 @@ func TestCoffeeBeansService_Delete(t *testing.T) {
 		"別ユーザーのbeanはErrForbiddenを返す": {
 			setup: func(ctrl *gomock.Controller) *usecase.CoffeeBeansService {
 				r := mock.NewMockCoffeeBeanRepository(ctrl)
-				r.EXPECT().GetByID(gomock.Any(), beanID).Return(testBean, nil)
-				return usecase.NewCoffeeBeansService(r, nil)
+				store := mock.NewMockStore(ctrl)
+				store.EXPECT().CoffeeBeanRepo().Return(r).AnyTimes()
+				r.EXPECT().GetByIDForUpdate(gomock.Any(), beanID).Return(testBean, nil)
+				uow := fakeRunInTx(ctrl, store)
+				return usecase.NewCoffeeBeansService(r, uow)
 			},
 			in:      usecase.DeleteBeanInput{UserID: otherUserID, BeanID: beanID},
 			wantErr: domain.ErrForbidden,
@@ -509,9 +537,12 @@ func TestCoffeeBeansService_Delete(t *testing.T) {
 		"SoftDeleteのエラーが伝播する": {
 			setup: func(ctrl *gomock.Controller) *usecase.CoffeeBeansService {
 				r := mock.NewMockCoffeeBeanRepository(ctrl)
-				r.EXPECT().GetByID(gomock.Any(), beanID).Return(testBean, nil)
+				store := mock.NewMockStore(ctrl)
+				store.EXPECT().CoffeeBeanRepo().Return(r).AnyTimes()
+				r.EXPECT().GetByIDForUpdate(gomock.Any(), beanID).Return(testBean, nil)
 				r.EXPECT().SoftDelete(gomock.Any(), beanID, userID).Return(errors.New("db error"))
-				return usecase.NewCoffeeBeansService(r, nil)
+				uow := fakeRunInTx(ctrl, store)
+				return usecase.NewCoffeeBeansService(r, uow)
 			},
 			in: usecase.DeleteBeanInput{UserID: userID, BeanID: beanID},
 		},

--- a/backend/internal/usecase/mock/mock_coffeebean_repository.go
+++ b/backend/internal/usecase/mock/mock_coffeebean_repository.go
@@ -72,6 +72,21 @@ func (mr *MockCoffeeBeanRepositoryMockRecorder) GetByID(ctx, id any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByID", reflect.TypeOf((*MockCoffeeBeanRepository)(nil).GetByID), ctx, id)
 }
 
+// GetByIDForUpdate mocks base method.
+func (m *MockCoffeeBeanRepository) GetByIDForUpdate(ctx context.Context, id uuid.UUID) (*coffeebean.CoffeeBean, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByIDForUpdate", ctx, id)
+	ret0, _ := ret[0].(*coffeebean.CoffeeBean)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByIDForUpdate indicates an expected call of GetByIDForUpdate.
+func (mr *MockCoffeeBeanRepositoryMockRecorder) GetByIDForUpdate(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByIDForUpdate", reflect.TypeOf((*MockCoffeeBeanRepository)(nil).GetByIDForUpdate), ctx, id)
+}
+
 // ListByUserID mocks base method.
 func (m *MockCoffeeBeanRepository) ListByUserID(ctx context.Context, userID uuid.UUID, limit, offset int32) ([]*coffeebean.CoffeeBean, error) {
 	m.ctrl.T.Helper()

--- a/backend/sql/queries.sql
+++ b/backend/sql/queries.sql
@@ -40,6 +40,11 @@ RETURNING *;
 SELECT * FROM coffee_beans
 WHERE id = $1 AND deleted_at IS NULL;
 
+-- name: GetCoffeeBeanByIDForUpdate :one
+SELECT * FROM coffee_beans
+WHERE id = $1 AND deleted_at IS NULL
+FOR UPDATE;
+
 -- name: ListCoffeeBeansByUserID :many
 SELECT * FROM coffee_beans
 WHERE user_id = $1 AND deleted_at IS NULL


### PR DESCRIPTION
## Overview

- `RegisterAnonymous`のトークン生成とDB保存の順序を修正し、孤立レコードを防止
- `Update`/`Delete`に`SELECT ... FOR UPDATE` + `RunInTx`による悲観ロックを導入し、lost updateを防止
- `coffeeBeanRepository.Update`の`pgx.ErrNoRows`→`domain.ErrNotFound`変換を追加（500→404修正）
- `coffee_bean_repository_test.go`を新規追加（全メソッド23テストケース）

## Reference

Notion チケット:

ADR:

## Debug List

## Review Deadline