### PR TITLE
refactor(frontend): 焙煎度定数の統合

### DIFF
--- a/frontend/app/(tabs)/beans/[id].tsx
+++ b/frontend/app/(tabs)/beans/[id].tsx
@@ -17,50 +17,7 @@ import { usagesApi } from "../../../src/api/usages";
 import { ApiError } from "../../../src/api/client";
 import type { CoffeeBean, RoastLevel, RoastDetail, UsageHistory } from "../../../src/types/api";
 import { colors, typography, spacing, radius, shadows, getStockColor } from "@/theme";
-
-const ROAST_LEVELS: { value: RoastLevel; label: string }[] = [
-  { value: "shallow", label: "浅煎り" },
-  { value: "medium", label: "中煎り" },
-  { value: "medium_deep", label: "中深煎り" },
-  { value: "deep", label: "深煎り" },
-];
-
-const ROAST_DETAILS: Record<RoastLevel, { value: RoastDetail; label: string }[]> = {
-  shallow: [
-    { value: "light", label: "ライトロースト" },
-    { value: "cinnamon", label: "シナモンロースト" },
-  ],
-  medium: [
-    { value: "medium", label: "ミディアムロースト" },
-    { value: "high", label: "ハイロースト" },
-  ],
-  medium_deep: [
-    { value: "city", label: "シティロースト" },
-    { value: "full_city", label: "フルシティロースト" },
-  ],
-  deep: [
-    { value: "french", label: "フレンチロースト" },
-    { value: "italian", label: "イタリアンロースト" },
-  ],
-};
-
-const ROAST_LEVEL_LABELS: Record<RoastLevel, string> = {
-  shallow: "浅煎り",
-  medium: "中煎り",
-  medium_deep: "中深煎り",
-  deep: "深煎り",
-};
-
-const ROAST_DETAIL_LABELS: Record<RoastDetail, string> = {
-  light: "ライトロースト",
-  cinnamon: "シナモンロースト",
-  medium: "ミディアムロースト",
-  high: "ハイロースト",
-  city: "シティロースト",
-  full_city: "フルシティロースト",
-  french: "フレンチロースト",
-  italian: "イタリアンロースト",
-};
+import { ROAST_LEVELS, ROAST_DETAILS, ROAST_LEVEL_LABELS, ROAST_DETAIL_LABELS } from "../../../src/constants/roastLevels";
 
 export default function BeanDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();

--- a/frontend/app/(tabs)/beans/create.tsx
+++ b/frontend/app/(tabs)/beans/create.tsx
@@ -15,32 +15,7 @@ import { beansApi } from "../../../src/api/beans";
 import { ApiError } from "../../../src/api/client";
 import type { RoastLevel, RoastDetail } from "../../../src/types/api";
 import { colors, typography, spacing, radius, shadows } from "@/theme";
-
-const ROAST_LEVELS: { value: RoastLevel; label: string }[] = [
-  { value: "shallow", label: "浅煎り" },
-  { value: "medium", label: "中煎り" },
-  { value: "medium_deep", label: "中深煎り" },
-  { value: "deep", label: "深煎り" },
-];
-
-const ROAST_DETAILS: Record<RoastLevel, { value: RoastDetail; label: string }[]> = {
-  shallow: [
-    { value: "light", label: "ライトロースト" },
-    { value: "cinnamon", label: "シナモンロースト" },
-  ],
-  medium: [
-    { value: "medium", label: "ミディアムロースト" },
-    { value: "high", label: "ハイロースト" },
-  ],
-  medium_deep: [
-    { value: "city", label: "シティロースト" },
-    { value: "full_city", label: "フルシティロースト" },
-  ],
-  deep: [
-    { value: "french", label: "フレンチロースト" },
-    { value: "italian", label: "イタリアンロースト" },
-  ],
-};
+import { ROAST_LEVELS, ROAST_DETAILS } from "../../../src/constants/roastLevels";
 
 export default function CreateBeanScreen() {
   const [name, setName] = useState("");

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -11,15 +11,9 @@ import {
 } from "react-native";
 import { useFocusEffect, useRouter } from "expo-router";
 import { beansApi } from "../../src/api/beans";
-import type { CoffeeBean, RoastLevel } from "../../src/types/api";
+import type { CoffeeBean } from "../../src/types/api";
 import { colors, typography, spacing, radius, shadows, getStockColor } from "@/theme";
-
-const ROAST_LEVEL_LABELS: Record<RoastLevel, string> = {
-  shallow: "浅煎り",
-  medium: "中煎り",
-  medium_deep: "中深煎り",
-  deep: "深煎り",
-};
+import { ROAST_LEVEL_LABELS } from "../../src/constants/roastLevels";
 
 export default function BeansListScreen() {
   const [beans, setBeans] = useState<CoffeeBean[]>([]);

--- a/frontend/src/constants/roastLevels.ts
+++ b/frontend/src/constants/roastLevels.ts
@@ -1,0 +1,45 @@
+import type { RoastLevel, RoastDetail } from "../types/api";
+
+export const ROAST_LEVELS: { value: RoastLevel; label: string }[] = [
+  { value: "shallow", label: "浅煎り" },
+  { value: "medium", label: "中煎り" },
+  { value: "medium_deep", label: "中深煎り" },
+  { value: "deep", label: "深煎り" },
+];
+
+export const ROAST_DETAILS: Record<RoastLevel, { value: RoastDetail; label: string }[]> = {
+  shallow: [
+    { value: "light", label: "ライトロースト" },
+    { value: "cinnamon", label: "シナモンロースト" },
+  ],
+  medium: [
+    { value: "medium", label: "ミディアムロースト" },
+    { value: "high", label: "ハイロースト" },
+  ],
+  medium_deep: [
+    { value: "city", label: "シティロースト" },
+    { value: "full_city", label: "フルシティロースト" },
+  ],
+  deep: [
+    { value: "french", label: "フレンチロースト" },
+    { value: "italian", label: "イタリアンロースト" },
+  ],
+};
+
+export const ROAST_LEVEL_LABELS: Record<RoastLevel, string> = {
+  shallow: "浅煎り",
+  medium: "中煎り",
+  medium_deep: "中深煎り",
+  deep: "深煎り",
+};
+
+export const ROAST_DETAIL_LABELS: Record<RoastDetail, string> = {
+  light: "ライトロースト",
+  cinnamon: "シナモンロースト",
+  medium: "ミディアムロースト",
+  high: "ハイロースト",
+  city: "シティロースト",
+  full_city: "フルシティロースト",
+  french: "フレンチロースト",
+  italian: "イタリアンロースト",
+};


### PR DESCRIPTION
## Summary
- 3画面ファイルに散在していた焙煎度定数(`ROAST_LEVELS`, `ROAST_DETAILS`, `ROAST_LEVEL_LABELS`, `ROAST_DETAIL_LABELS`)を `src/constants/roastLevels.ts` に統合
- 各画面ファイル(`create.tsx`, `[id].tsx`, `index.tsx`)から重複定数を削除し、共通ファイルからインポートするよう変更

## Changes
- 新規: `frontend/src/constants/roastLevels.ts` — 全焙煎度定数を集約
- 変更: `frontend/app/(tabs)/beans/create.tsx` — `ROAST_LEVELS`, `ROAST_DETAILS` のインライン定義を削除
- 変更: `frontend/app/(tabs)/beans/[id].tsx` — 4定数のインライン定義を削除
- 変更: `frontend/app/(tabs)/index.tsx` — `ROAST_LEVEL_LABELS` のインライン定義を削除

## Related Issue
Closes #79

## Acceptance Criteria
- ✅ `src/constants/roastLevels.ts` に全焙煎度定数を定義
- ✅ 3つの画面ファイルから重複定数を削除し、共通ファイルからインポート
- ✅ `npx tsc --noEmit` が通ること
- ✅ 既存テストがパスすること (11/11)

## Test plan
- [x] `npx tsc --noEmit` パス
- [x] `npx jest` 全テストパス (11/11)
- [ ] 豆一覧画面で焙煎度ラベルが正しく表示される
- [ ] 豆作成画面で焙煎度チップが正しく動作する
- [ ] 豆詳細画面で焙煎度表示・編集が正しく動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)