### PR TITLE
chore(backend): Go 1.26.0 → 1.26.1 にバージョンアップ

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/k3forx/CoffeeBeansStock/backend
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5


### PR DESCRIPTION
## Overview

- Go のバージョンを 1.26.0 → 1.26.1 にアップデート（`go.mod`）

## Reference

Notion チケット:

ADR:

## Debug List

## Review Deadline