### PR TITLE
refactor(frontend): ChipSelectorコンポーネントの抽出

### DIFF
--- a/frontend/app/(tabs)/beans/[id].tsx
+++ b/frontend/app/(tabs)/beans/[id].tsx
@@ -18,6 +18,7 @@ import { ApiError } from "../../../src/api/client";
 import type { CoffeeBean, RoastLevel, RoastDetail, UsageHistory } from "../../../src/types/api";
 import { colors, typography, spacing, radius, shadows, getStockColor } from "@/theme";
 import { ROAST_LEVELS, ROAST_DETAILS, ROAST_LEVEL_LABELS, ROAST_DETAIL_LABELS } from "../../../src/constants/roastLevels";
+import { ChipSelector } from "../../../src/components/ChipSelector";
 
 export default function BeanDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -278,45 +279,20 @@ export default function BeanDetailScreen() {
             />
 
             <Text style={styles.label}>焙煎度 *</Text>
-            <View style={styles.chipContainer}>
-              {ROAST_LEVELS.map((level) => (
-                <TouchableOpacity
-                  key={level.value}
-                  style={[styles.chip, roastLevel === level.value && styles.chipSelected]}
-                  onPress={() => handleRoastLevelSelect(level.value)}
-                >
-                  <Text
-                    style={[styles.chipText, roastLevel === level.value && styles.chipTextSelected]}
-                  >
-                    {level.label}
-                  </Text>
-                </TouchableOpacity>
-              ))}
-            </View>
+            <ChipSelector
+              items={ROAST_LEVELS}
+              selected={roastLevel}
+              onSelect={handleRoastLevelSelect}
+            />
 
             {roastLevel !== "" && (
               <>
                 <Text style={styles.label}>焙煎度（詳細）</Text>
-                <View style={styles.chipContainer}>
-                  {ROAST_DETAILS[roastLevel].map((detail) => (
-                    <TouchableOpacity
-                      key={detail.value}
-                      style={[styles.chip, roastDetail === detail.value && styles.chipSelected]}
-                      onPress={() =>
-                        setRoastDetail(roastDetail === detail.value ? "" : detail.value)
-                      }
-                    >
-                      <Text
-                        style={[
-                          styles.chipText,
-                          roastDetail === detail.value && styles.chipTextSelected,
-                        ]}
-                      >
-                        {detail.label}
-                      </Text>
-                    </TouchableOpacity>
-                  ))}
-                </View>
+                <ChipSelector
+                  items={ROAST_DETAILS[roastLevel]}
+                  selected={roastDetail}
+                  onSelect={(v) => setRoastDetail(roastDetail === v ? "" : v)}
+                />
               </>
             )}
 
@@ -577,30 +553,6 @@ const styles = StyleSheet.create({
     backgroundColor: "transparent",
   },
   textArea: { height: 100, textAlignVertical: "top" },
-  chipContainer: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: spacing.sm,
-  },
-  chip: {
-    paddingVertical: spacing.sm,
-    paddingHorizontal: spacing.lg,
-    borderRadius: radius.full,
-    borderWidth: 1,
-    borderColor: colors.border,
-    backgroundColor: colors.background,
-  },
-  chipSelected: {
-    backgroundColor: colors.primary,
-    borderColor: colors.primary,
-  },
-  chipText: {
-    ...typography.bodyMedium,
-    color: colors.textSecondary,
-  },
-  chipTextSelected: {
-    color: colors.textInverse,
-  },
   editActions: { flexDirection: "row", gap: spacing.md, marginTop: spacing["3xl"] },
   button: { flex: 1, borderRadius: radius.sm, padding: spacing.lg, alignItems: "center" },
   cancelButton: {

--- a/frontend/app/(tabs)/beans/create.tsx
+++ b/frontend/app/(tabs)/beans/create.tsx
@@ -8,7 +8,6 @@ import {
   KeyboardAvoidingView,
   Platform,
   ScrollView,
-  View,
 } from "react-native";
 import { useRouter } from "expo-router";
 import { beansApi } from "../../../src/api/beans";
@@ -16,6 +15,7 @@ import { ApiError } from "../../../src/api/client";
 import type { RoastLevel, RoastDetail } from "../../../src/types/api";
 import { colors, typography, spacing, radius, shadows } from "@/theme";
 import { ROAST_LEVELS, ROAST_DETAILS } from "../../../src/constants/roastLevels";
+import { ChipSelector } from "../../../src/components/ChipSelector";
 
 export default function CreateBeanScreen() {
   const [name, setName] = useState("");
@@ -93,45 +93,20 @@ export default function CreateBeanScreen() {
         />
 
         <Text style={styles.label}>焙煎度 *</Text>
-        <View style={styles.chipContainer}>
-          {ROAST_LEVELS.map((level) => (
-            <TouchableOpacity
-              key={level.value}
-              style={[styles.chip, roastLevel === level.value && styles.chipSelected]}
-              onPress={() => handleRoastLevelSelect(level.value)}
-            >
-              <Text
-                style={[styles.chipText, roastLevel === level.value && styles.chipTextSelected]}
-              >
-                {level.label}
-              </Text>
-            </TouchableOpacity>
-          ))}
-        </View>
+        <ChipSelector
+          items={ROAST_LEVELS}
+          selected={roastLevel}
+          onSelect={handleRoastLevelSelect}
+        />
 
         {roastLevel !== "" && (
           <>
             <Text style={styles.label}>焙煎度（詳細）</Text>
-            <View style={styles.chipContainer}>
-              {ROAST_DETAILS[roastLevel].map((detail) => (
-                <TouchableOpacity
-                  key={detail.value}
-                  style={[styles.chip, roastDetail === detail.value && styles.chipSelected]}
-                  onPress={() =>
-                    setRoastDetail(roastDetail === detail.value ? "" : detail.value)
-                  }
-                >
-                  <Text
-                    style={[
-                      styles.chipText,
-                      roastDetail === detail.value && styles.chipTextSelected,
-                    ]}
-                  >
-                    {detail.label}
-                  </Text>
-                </TouchableOpacity>
-              ))}
-            </View>
+            <ChipSelector
+              items={ROAST_DETAILS[roastLevel]}
+              selected={roastDetail}
+              onSelect={(v) => setRoastDetail(roastDetail === v ? "" : v)}
+            />
           </>
         )}
 
@@ -193,30 +168,6 @@ const styles = StyleSheet.create({
     letterSpacing: 0,
   },
   textArea: { height: 100, textAlignVertical: "top" },
-  chipContainer: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: spacing.sm,
-  },
-  chip: {
-    paddingVertical: spacing.sm,
-    paddingHorizontal: spacing.lg,
-    borderRadius: radius.full,
-    borderWidth: 1,
-    borderColor: colors.border,
-    backgroundColor: colors.background,
-  },
-  chipSelected: {
-    backgroundColor: colors.primary,
-    borderColor: colors.primary,
-  },
-  chipText: {
-    ...typography.bodyMedium,
-    color: colors.textSecondary,
-  },
-  chipTextSelected: {
-    color: colors.textInverse,
-  },
   button: {
     backgroundColor: colors.primary,
     borderRadius: radius.sm,

--- a/frontend/src/components/ChipSelector.tsx
+++ b/frontend/src/components/ChipSelector.tsx
@@ -1,0 +1,58 @@
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+import { colors, typography, spacing, radius } from "@/theme";
+
+interface ChipItem<T extends string> {
+  label: string;
+  value: T;
+}
+
+interface ChipSelectorProps<T extends string> {
+  items: ChipItem<T>[];
+  selected: T | "";
+  onSelect: (value: T) => void;
+}
+
+export function ChipSelector<T extends string>({ items, selected, onSelect }: ChipSelectorProps<T>) {
+  return (
+    <View style={styles.chipContainer}>
+      {items.map((item) => (
+        <TouchableOpacity
+          key={item.value}
+          style={[styles.chip, selected === item.value && styles.chipSelected]}
+          onPress={() => onSelect(item.value)}
+        >
+          <Text style={[styles.chipText, selected === item.value && styles.chipTextSelected]}>
+            {item.label}
+          </Text>
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  chipContainer: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.sm,
+  },
+  chip: {
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    borderRadius: radius.full,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.background,
+  },
+  chipSelected: {
+    backgroundColor: colors.primary,
+    borderColor: colors.primary,
+  },
+  chipText: {
+    ...typography.bodyMedium,
+    color: colors.textSecondary,
+  },
+  chipTextSelected: {
+    color: colors.textInverse,
+  },
+});


### PR DESCRIPTION
## Summary
- `src/components/ChipSelector.tsx` を新規作成（ジェネリック型対応の再利用可能チップ選択コンポーネント）
- `create.tsx` と `[id].tsx` の重複チップUI（JSX + 5スタイル定義）を `ChipSelector` に置換
- 結果: 3ファイル変更、+80行 / -119行（ネット -39行）

Closes #80

## Test plan
- [ ] `npx tsc --noEmit` パス済み（CI確認）
- [ ] 新規豆登録画面で焙煎度・焙煎詳細のチップ選択が正常動作すること
- [ ] 豆詳細編集画面で焙煎度・焙煎詳細のチップ選択が正常動作すること
- [ ] チップのトグル動作（焙煎詳細の選択/解除）が維持されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)