### PR TITLE
refactor(frontend): フォームバリデーションロジックをユーティリティに統合

### DIFF
--- a/frontend/app/(tabs)/beans/[id].tsx
+++ b/frontend/app/(tabs)/beans/[id].tsx
@@ -19,6 +19,7 @@ import type { CoffeeBean, RoastLevel, RoastDetail, UsageHistory } from "../../..
 import { colors, typography, spacing, radius, shadows, getStockColor } from "@/theme";
 import { ROAST_LEVELS, ROAST_DETAILS, ROAST_LEVEL_LABELS, ROAST_DETAIL_LABELS } from "../../../src/constants/roastLevels";
 import { ChipSelector } from "../../../src/components/ChipSelector";
+import { validateBeanForm } from "../../../src/utils/validation";
 
 export default function BeanDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -173,28 +174,17 @@ export default function BeanDetailScreen() {
   };
 
   const handleSave = async () => {
-    if (!name) {
-      Alert.alert("エラー", "名前は必須です");
-      return;
-    }
-    if (!roastLevel) {
-      Alert.alert("エラー", "焙煎度を選択してください");
-      return;
-    }
-    const stock = parseInt(currentStock, 10);
-    if (isNaN(stock) || stock < 0) {
-      Alert.alert("エラー", "在庫数は0以上の数値を入力してください");
-      return;
-    }
+    const result = validateBeanForm({ name, roastLevel, currentStock });
+    if (!result.valid) return;
 
     setSaving(true);
     try {
       const updated = await beansApi.update(id, {
         name,
         origin: origin || undefined,
-        roast_level: roastLevel,
+        roast_level: roastLevel as RoastLevel,
         roast_detail: roastDetail || undefined,
-        current_stock: stock,
+        current_stock: result.stock,
         notes: notes || undefined,
       });
       setBean(updated);

--- a/frontend/app/(tabs)/beans/create.tsx
+++ b/frontend/app/(tabs)/beans/create.tsx
@@ -4,10 +4,10 @@ import {
   TextInput,
   TouchableOpacity,
   StyleSheet,
-  Alert,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
+  Alert,
 } from "react-native";
 import { useRouter } from "expo-router";
 import { beansApi } from "../../../src/api/beans";
@@ -16,6 +16,7 @@ import type { RoastLevel, RoastDetail } from "../../../src/types/api";
 import { colors, typography, spacing, radius, shadows } from "@/theme";
 import { ROAST_LEVELS, ROAST_DETAILS } from "../../../src/constants/roastLevels";
 import { ChipSelector } from "../../../src/components/ChipSelector";
+import { validateBeanForm } from "../../../src/utils/validation";
 
 export default function CreateBeanScreen() {
   const [name, setName] = useState("");
@@ -33,28 +34,17 @@ export default function CreateBeanScreen() {
   };
 
   const handleCreate = async () => {
-    if (!name) {
-      Alert.alert("エラー", "名前は必須です");
-      return;
-    }
-    if (!roastLevel) {
-      Alert.alert("エラー", "焙煎度を選択してください");
-      return;
-    }
-    const stock = parseInt(currentStock, 10);
-    if (isNaN(stock) || stock < 0) {
-      Alert.alert("エラー", "在庫数は0以上の数値を入力してください");
-      return;
-    }
+    const result = validateBeanForm({ name, roastLevel, currentStock });
+    if (!result.valid) return;
 
     setLoading(true);
     try {
       await beansApi.create({
         name,
         origin: origin || undefined,
-        roast_level: roastLevel,
+        roast_level: roastLevel as RoastLevel,
         roast_detail: roastDetail || undefined,
-        current_stock: stock,
+        current_stock: result.stock,
         notes: notes || undefined,
       });
       router.back();

--- a/frontend/src/utils/validation.ts
+++ b/frontend/src/utils/validation.ts
@@ -1,0 +1,22 @@
+import { Alert } from "react-native";
+
+export function validateBeanForm(params: {
+  name: string;
+  roastLevel: string;
+  currentStock: string;
+}): { valid: false } | { valid: true; stock: number } {
+  if (!params.name) {
+    Alert.alert("エラー", "名前は必須です");
+    return { valid: false };
+  }
+  if (!params.roastLevel) {
+    Alert.alert("エラー", "焙煎度を選択してください");
+    return { valid: false };
+  }
+  const stock = parseInt(params.currentStock, 10);
+  if (isNaN(stock) || stock < 0) {
+    Alert.alert("エラー", "在庫数は0以上の数値を入力してください");
+    return { valid: false };
+  }
+  return { valid: true, stock };
+}


### PR DESCRIPTION
## Overview

- `create.tsx` と `[id].tsx` で重複していたバリデーションロジック（名前必須、焙煎度選択必須、在庫数チェック）を `src/utils/validation.ts` に抽出
- 両画面から共通関数 `validateBeanForm` を呼び出すように変更

## Reference

Closes #81

## Debug List

- [ ] 作成画面: 名前空欄でエラー表示
- [ ] 作成画面: 焙煎度未選択でエラー表示
- [ ] 作成画面: 在庫数に負値/非数値でエラー表示
- [ ] 編集画面: 同上3パターン
- [ ] `npx tsc --noEmit` パス確認済み

## Review Deadline

🤖 Generated with [Claude Code](https://claude.com/claude-code)