### PR TITLE
feat(frontend): 1杯あたりのグラム数のユーザー設定UI (#94)

### DIFF
--- a/frontend/app/(tabs)/beans/[id].tsx
+++ b/frontend/app/(tabs)/beans/[id].tsx
@@ -15,6 +15,7 @@ import { useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
 import { beansApi } from "../../../src/api/beans";
 import { usagesApi } from "../../../src/api/usages";
 import { ApiError } from "../../../src/api/client";
+import { useAuthStore } from "../../../src/stores/auth";
 import type { CoffeeBean, RoastLevel, RoastDetail, UsageHistory } from "../../../src/types/api";
 import { colors, typography, spacing, radius, shadows, getStockColor } from "@/theme";
 import { ROAST_LEVELS, ROAST_DETAILS, ROAST_LEVEL_LABELS, ROAST_DETAIL_LABELS } from "../../../src/constants/roastLevels";
@@ -42,8 +43,9 @@ export default function BeanDetailScreen() {
   const [manualGrams, setManualGrams] = useState("");
   const [manualLoading, setManualLoading] = useState(false);
   const [deletingUsageId, setDeletingUsageId] = useState<string | null>(null);
+  const { user } = useAuthStore();
 
-  const QUICK_USAGE_GRAMS = 15;
+  const QUICK_USAGE_GRAMS = user?.grams_per_cup ?? 15;
 
   const loadBean = useCallback(async () => {
     try {
@@ -375,7 +377,7 @@ export default function BeanDetailScreen() {
                 disabled={quickButtonLoading}
               >
                 <Text style={styles.quickButtonText}>
-                  {quickButtonLoading ? "記録中..." : "1杯使った (15g)"}
+                  {quickButtonLoading ? "記録中..." : `1杯使った (${QUICK_USAGE_GRAMS}g)`}
                 </Text>
               </TouchableOpacity>
 

--- a/frontend/app/(tabs)/profile.tsx
+++ b/frontend/app/(tabs)/profile.tsx
@@ -1,9 +1,15 @@
-import { View, Text, TouchableOpacity, StyleSheet, Alert } from "react-native";
+import { useState } from "react";
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, Alert } from "react-native";
 import { useAuthStore } from "../../src/stores/auth";
+import { usersApi } from "../../src/api/users";
+import { ApiError } from "../../src/api/client";
 import { colors, typography, spacing, radius, shadows } from "@/theme";
 
 export default function ProfileScreen() {
-  const { user, logout } = useAuthStore();
+  const { user, logout, setUser } = useAuthStore();
+  const [editingGrams, setEditingGrams] = useState(false);
+  const [gramsInput, setGramsInput] = useState("");
+  const [saving, setSaving] = useState(false);
 
   const handleLogout = () => {
     Alert.alert("ログアウト", "ログアウトしますか？", [
@@ -14,6 +20,30 @@ export default function ProfileScreen() {
         onPress: () => logout(),
       },
     ]);
+  };
+
+  const handleStartEditGrams = () => {
+    setGramsInput(String(user?.grams_per_cup ?? 15));
+    setEditingGrams(true);
+  };
+
+  const handleSaveGrams = async () => {
+    const value = parseInt(gramsInput, 10);
+    if (isNaN(value) || value < 1 || value > 100) {
+      Alert.alert("エラー", "1〜100の範囲で入力してください");
+      return;
+    }
+    setSaving(true);
+    try {
+      const updated = await usersApi.updateMe({ grams_per_cup: value });
+      setUser(updated);
+      setEditingGrams(false);
+    } catch (e) {
+      const msg = e instanceof ApiError ? e.message : "更新に失敗しました";
+      Alert.alert("エラー", msg);
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
@@ -34,11 +64,47 @@ export default function ProfileScreen() {
             {user?.low_stock_threshold ?? 100}g以下
           </Text>
         </View>
-        <View style={[styles.settingRow, { borderBottomWidth: 0 }]}>
+        <View style={styles.settingRow}>
           <Text style={styles.settingLabel}>通知</Text>
           <Text style={styles.settingValue}>
             {user?.notification_enabled ? "ON" : "OFF"}
           </Text>
+        </View>
+        <View style={[styles.settingRow, { borderBottomWidth: 0 }]}>
+          <Text style={styles.settingLabel}>1杯あたりのグラム数</Text>
+          {editingGrams ? (
+            <View style={styles.editGramsRow}>
+              <TextInput
+                style={styles.gramsInput}
+                value={gramsInput}
+                onChangeText={setGramsInput}
+                keyboardType="number-pad"
+                autoFocus
+                selectTextOnFocus
+              />
+              <Text style={styles.gramsUnit}>g</Text>
+              <TouchableOpacity
+                style={[styles.gramsButton, saving && styles.buttonDisabled]}
+                onPress={handleSaveGrams}
+                disabled={saving}
+              >
+                <Text style={styles.gramsButtonText}>{saving ? "..." : "保存"}</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.gramsCancelButton}
+                onPress={() => setEditingGrams(false)}
+                disabled={saving}
+              >
+                <Text style={styles.gramsCancelText}>取消</Text>
+              </TouchableOpacity>
+            </View>
+          ) : (
+            <TouchableOpacity onPress={handleStartEditGrams}>
+              <Text style={styles.settingValueTappable}>
+                {user?.grams_per_cup ?? 15}g
+              </Text>
+            </TouchableOpacity>
+          )}
         </View>
       </View>
 
@@ -103,6 +169,7 @@ const styles = StyleSheet.create({
   settingRow: {
     flexDirection: "row",
     justifyContent: "space-between",
+    alignItems: "center",
     paddingVertical: spacing.lg,
     paddingHorizontal: spacing.xl,
     borderBottomWidth: StyleSheet.hairlineWidth,
@@ -116,6 +183,49 @@ const styles = StyleSheet.create({
     ...typography.bodyMedium,
     color: colors.textSecondary,
   },
+  settingValueTappable: {
+    ...typography.bodyMedium,
+    color: colors.accentDark,
+    textDecorationLine: "underline",
+  },
+  editGramsRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+  },
+  gramsInput: {
+    width: 48,
+    height: 32,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.primary,
+    textAlign: "center",
+    ...typography.bodyMedium,
+    color: colors.textPrimary,
+    padding: 0,
+  },
+  gramsUnit: {
+    ...typography.bodyMedium,
+    color: colors.textSecondary,
+  },
+  gramsButton: {
+    backgroundColor: colors.primary,
+    borderRadius: radius.sm,
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.md,
+  },
+  gramsButtonText: {
+    ...typography.labelSmall,
+    color: colors.textInverse,
+  },
+  gramsCancelButton: {
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.sm,
+  },
+  gramsCancelText: {
+    ...typography.labelSmall,
+    color: colors.textSecondary,
+  },
+  buttonDisabled: { opacity: 0.6 },
   logoutText: {
     ...typography.bodyMedium,
     color: colors.danger,

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -1,0 +1,7 @@
+import { api } from "./client";
+import type { UpdateUserInput, UserResponse } from "../types/api";
+
+export const usersApi = {
+  updateMe: (input: UpdateUserInput) =>
+    api.put<UserResponse>("/auth/me", input),
+};

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -11,6 +11,7 @@ interface AuthState {
 
   setAuth: (user: UserResponse, accessToken: string, refreshToken: string) => Promise<void>;
   setTokens: (accessToken: string, refreshToken: string) => Promise<void>;
+  setUser: (user: UserResponse) => void;
   logout: () => Promise<void>;
   loadStoredTokens: () => Promise<void>;
 }
@@ -27,6 +28,8 @@ export const useAuthStore = create<AuthState>((set, _get) => ({
     await SecureStore.setItemAsync("refresh_token", refreshToken);
     set({ user, accessToken, refreshToken, isAuthenticated: true });
   },
+
+  setUser: (user) => set({ user }),
 
   setTokens: async (accessToken, refreshToken) => {
     await SecureStore.setItemAsync("access_token", accessToken);

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -14,6 +14,7 @@ export type RoastDetail = components["schemas"]["RoastDetail"];
 export type CreateUsageInput = components["schemas"]["CreateUsageHistoryRequest"];
 export type UsageHistory = components["schemas"]["UsageHistoryResponse"];
 export type ListUsageHistoryResult = components["schemas"]["ListUsageHistoryResponse"];
+export type UpdateUserInput = components["schemas"]["UpdateUserRequest"];
 
 // Envelope type used internally by client.ts
 export type ApiResponse<T> = {

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -64,7 +64,8 @@ export interface paths {
         };
         /** 認証ユーザー情報取得 */
         get: operations["getMe"];
-        put?: never;
+        /** ユーザー設定更新 */
+        put: operations["updateMe"];
         post?: never;
         delete?: never;
         options?: never;
@@ -162,6 +163,8 @@ export interface components {
             /** Format: int32 */
             low_stock_threshold?: number;
             notification_enabled?: boolean;
+            /** Format: int32 */
+            grams_per_cup?: number;
             /** Format: date-time */
             created_at: string;
             /** Format: date-time */
@@ -178,6 +181,13 @@ export interface components {
         RefreshResult: {
             access_token: string;
             refresh_token: string;
+        };
+        UpdateUserRequest: {
+            /** Format: int32 */
+            low_stock_threshold?: number;
+            notification_enabled?: boolean;
+            /** Format: int32 */
+            grams_per_cup?: number;
         };
         /** @enum {string} */
         RoastLevel: "shallow" | "medium" | "medium_deep" | "deep";
@@ -360,6 +370,44 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["UserResponse"];
                 };
+            };
+            /** @description 認証エラー */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    updateMe: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateUserRequest"];
+            };
+        };
+        responses: {
+            /** @description 更新成功 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserResponse"];
+                };
+            };
+            /** @description バリデーションエラー */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description 認証エラー */
             401: {


### PR DESCRIPTION
## Summary

- プロフィール画面に「1杯あたりのグラム数」設定行を追加（タップで編集モード）
- クライアント側バリデーション（1〜100の範囲）
- `usersApi.updateMe()` で `PUT /auth/me` を呼び出し、ストアを更新
- 豆詳細画面のクイックボタンがユーザー設定値を参照（`user?.grams_per_cup ?? 15`）
- ボタンラベルを動的表示（例: 「1杯使った (20g)」）

## Changes

| File | Change |
|---|---|
| `src/types/generated.ts` | OpenAPI spec から再生成 |
| `src/types/api.ts` | `UpdateUserInput` 型追加 |
| `src/api/users.ts` (new) | `usersApi.updateMe()` |
| `src/stores/auth.ts` | `setUser` アクション追加 |
| `app/(tabs)/profile.tsx` | グラム数設定行 + インライン編集UI |
| `app/(tabs)/beans/[id].tsx` | クイックボタンの動的化 |

## Test plan

- [ ] プロフィール画面で「1杯あたりのグラム数」が `15g` で表示される
- [ ] タップで編集モードに入り、値を変更して保存できる
- [ ] 0 や 101 を入力するとバリデーションエラー
- [ ] 保存後、豆詳細画面のクイックボタンに反映される（例: 「1杯使った (20g)」）
- [ ] `npx tsc --noEmit` 通過

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)