### PR TITLE
refactor(frontend): APIエラーハンドリングを showApiError に共通化

### DIFF
--- a/frontend/app/(tabs)/beans/[id].tsx
+++ b/frontend/app/(tabs)/beans/[id].tsx
@@ -15,7 +15,7 @@ import { Feather } from "@expo/vector-icons";
 import { useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
 import { beansApi } from "../../../src/api/beans";
 import { usagesApi } from "../../../src/api/usages";
-import { ApiError } from "../../../src/api/client";
+import { showApiError } from "../../../src/utils/errorHandler";
 import type { CoffeeBean, RoastLevel, RoastDetail, UsageHistory } from "../../../src/types/api";
 import { colors, typography, spacing, radius, shadows, getStockColor } from "@/theme";
 import { ROAST_LEVELS, ROAST_DETAILS, ROAST_LEVEL_LABELS, ROAST_DETAIL_LABELS } from "../../../src/constants/roastLevels";
@@ -115,12 +115,9 @@ export default function BeanDetailScreen() {
       });
       await refreshAfterUsage();
     } catch (e) {
-      if (e instanceof ApiError && e.code === "INSUFFICIENT_STOCK") {
-        Alert.alert("エラー", "在庫が不足しています");
-      } else {
-        const msg = e instanceof ApiError ? e.message : "記録に失敗しました";
-        Alert.alert("エラー", msg);
-      }
+      showApiError(e, "記録に失敗しました", {
+        INSUFFICIENT_STOCK: "在庫が不足しています",
+      });
     } finally {
       setQuickButtonLoading(null);
     }
@@ -141,12 +138,9 @@ export default function BeanDetailScreen() {
       await refreshAfterUsage();
       setManualGrams("");
     } catch (e) {
-      if (e instanceof ApiError && e.code === "INSUFFICIENT_STOCK") {
-        Alert.alert("エラー", "在庫が不足しています");
-      } else {
-        const msg = e instanceof ApiError ? e.message : "記録に失敗しました";
-        Alert.alert("エラー", msg);
-      }
+      showApiError(e, "記録に失敗しました", {
+        INSUFFICIENT_STOCK: "在庫が不足しています",
+      });
     } finally {
       setManualLoading(false);
     }
@@ -199,8 +193,7 @@ export default function BeanDetailScreen() {
       setBean(updated);
       setEditing(false);
     } catch (e) {
-      const msg = e instanceof ApiError ? e.message : "更新に失敗しました";
-      Alert.alert("エラー", msg);
+      showApiError(e, "更新に失敗しました");
     } finally {
       setSaving(false);
     }

--- a/frontend/app/(tabs)/beans/create.tsx
+++ b/frontend/app/(tabs)/beans/create.tsx
@@ -6,11 +6,10 @@ import {
   KeyboardAvoidingView,
   Platform,
   ScrollView,
-  Alert,
 } from "react-native";
 import { useRouter } from "expo-router";
 import { beansApi } from "../../../src/api/beans";
-import { ApiError } from "../../../src/api/client";
+import { showApiError } from "../../../src/utils/errorHandler";
 import type { RoastLevel, RoastDetail } from "../../../src/types/api";
 import { colors, typography, spacing, radius, shadows } from "@/theme";
 import { ROAST_LEVELS, ROAST_DETAILS } from "../../../src/constants/roastLevels";
@@ -54,8 +53,7 @@ export default function CreateBeanScreen() {
       });
       router.back();
     } catch (e) {
-      const msg = e instanceof ApiError ? e.message : "作成に失敗しました";
-      Alert.alert("エラー", msg);
+      showApiError(e, "作成に失敗しました");
     } finally {
       setLoading(false);
     }

--- a/frontend/app/(tabs)/profile.tsx
+++ b/frontend/app/(tabs)/profile.tsx
@@ -5,7 +5,7 @@ import { useFocusEffect } from "expo-router";
 import { useAuthStore } from "../../src/stores/auth";
 import { usersApi } from "../../src/api/users";
 import { beansApi } from "../../src/api/beans";
-import { ApiError } from "../../src/api/client";
+import { showApiError } from "../../src/utils/errorHandler";
 import { colors, typography, spacing, radius, shadows } from "@/theme";
 
 export default function ProfileScreen() {
@@ -49,8 +49,7 @@ export default function ProfileScreen() {
       setUser(updated);
       setEditingGrams(false);
     } catch (e) {
-      const msg = e instanceof ApiError ? e.message : "更新に失敗しました";
-      Alert.alert("エラー", msg);
+      showApiError(e, "更新に失敗しました");
     } finally {
       setSaving(false);
     }

--- a/frontend/app/auth/login.tsx
+++ b/frontend/app/auth/login.tsx
@@ -4,13 +4,12 @@ import {
   Text,
   TouchableOpacity,
   StyleSheet,
-  Alert,
   Animated,
 } from "react-native";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { authApi } from "../../src/api/auth";
 import { useAuthStore } from "../../src/stores/auth";
-import { ApiError } from "../../src/api/client";
+import { showApiError } from "../../src/utils/errorHandler";
 import { colors, typography, spacing, radius, shadows } from "@/theme";
 
 export default function LoginScreen() {
@@ -36,8 +35,7 @@ export default function LoginScreen() {
       const result = await authApi.registerAnonymous();
       await setAuth(result.user, result.access_token, result.refresh_token);
     } catch (e) {
-      const msg = e instanceof ApiError ? e.message : String(e);
-      Alert.alert("エラー", msg);
+      showApiError(e, "ログインに失敗しました");
     } finally {
       setLoading(false);
     }

--- a/frontend/src/utils/errorHandler.ts
+++ b/frontend/src/utils/errorHandler.ts
@@ -1,0 +1,15 @@
+import { Alert } from "react-native";
+import { ApiError } from "../api/client";
+
+export function showApiError(
+  e: unknown,
+  fallback = "エラーが発生しました",
+  codeMessages?: Record<string, string>,
+): void {
+  if (e instanceof ApiError) {
+    const overridden = codeMessages?.[e.code];
+    Alert.alert("エラー", overridden ?? e.message);
+  } else {
+    Alert.alert("エラー", fallback);
+  }
+}


### PR DESCRIPTION
## Summary
- `showApiError(e, fallback, codeMessages?)` ユーティリティを `src/utils/errorHandler.ts` に新規作成
- 4画面（create, [id], login, profile）計6箇所の重複catchパターンを共通関数に置換
- `codeMessages` マップで `INSUFFICIENT_STOCK` 等のコード別メッセージにも対応

closes #84

## Test plan
- [ ] `npx tsc --noEmit` パス確認済み
- [ ] 豆作成時のエラーアラート表示確認
- [ ] 豆詳細の更新・使用記録時のエラーアラート表示確認
- [ ] 在庫不足時の専用メッセージ表示確認
- [ ] ログイン失敗時のエラーアラート表示確認
- [ ] プロフィール更新時のエラーアラート表示確認