### PR TITLE
feat(backend): 認証エンドポイントにレートリミットを追加

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/go-chi/httprate v0.15.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
@@ -41,6 +42,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -62,6 +64,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.41.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -41,6 +41,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/go-chi/httprate v0.15.0 h1:j54xcWV9KGmPf/X4H32/aTH+wBlrvxL7P+SdnRqxh5g=
+github.com/go-chi/httprate v0.15.0/go.mod h1:rzGHhVrsBn3IMLYDOZQsSU4fJNWcjui4fWKJcCId1R4=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -69,6 +71,8 @@ github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
 github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
+github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
+github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -134,6 +138,8 @@ github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9R
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
+github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 h1:jq9TW8u3so/bN+JPT166wjOI6/vQPF6Xe7nMNIltagk=

--- a/backend/internal/api/middleware/ratelimit.go
+++ b/backend/internal/api/middleware/ratelimit.go
@@ -1,0 +1,21 @@
+package middleware
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/go-chi/httprate"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/api"
+)
+
+// RateLimit returns middleware that limits requests per IP address.
+func RateLimit(requestLimit int, windowLength time.Duration) func(http.Handler) http.Handler {
+	return httprate.Limit(
+		requestLimit,
+		windowLength,
+		httprate.WithKeyFuncs(httprate.KeyByIP),
+		httprate.WithLimitHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			api.WriteError(w, http.StatusTooManyRequests, "RATE_LIMIT_EXCEEDED", "リクエスト数の上限に達しました。しばらく経ってから再試行してください")
+		})),
+	)
+}

--- a/backend/internal/api/middleware/ratelimit_test.go
+++ b/backend/internal/api/middleware/ratelimit_test.go
@@ -1,0 +1,82 @@
+package middleware_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/api"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/api/middleware"
+)
+
+func TestRateLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		requestLimit int
+		numRequests  int
+		wantStatus   int
+	}{
+		"under_limit": {
+			requestLimit: 3,
+			numRequests:  2,
+			wantStatus:   http.StatusOK,
+		},
+		"at_limit": {
+			requestLimit: 3,
+			numRequests:  3,
+			wantStatus:   http.StatusOK,
+		},
+		"over_limit": {
+			requestLimit: 3,
+			numRequests:  4,
+			wantStatus:   http.StatusTooManyRequests,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := middleware.RateLimit(tt.requestLimit, time.Minute)(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}),
+			)
+
+			var lastRecorder *httptest.ResponseRecorder
+			for i := range tt.numRequests {
+				_ = i
+				rec := httptest.NewRecorder()
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.RemoteAddr = "192.0.2.1:1234"
+				handler.ServeHTTP(rec, req)
+				lastRecorder = rec
+			}
+
+			if lastRecorder.Code != tt.wantStatus {
+				t.Errorf("status code: got %d, want %d", lastRecorder.Code, tt.wantStatus)
+			}
+
+			if tt.wantStatus == http.StatusTooManyRequests {
+				var got api.Response
+				if err := json.NewDecoder(lastRecorder.Body).Decode(&got); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				want := api.Response{
+					Success: false,
+					Error: &api.ErrorBody{
+						Code:    "RATE_LIMIT_EXCEEDED",
+						Message: "リクエスト数の上限に達しました。しばらく経ってから再試行してください",
+					},
+				}
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("response mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
@@ -32,8 +33,8 @@ func New(deps Deps) chi.Router {
 
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Route("/auth", func(r chi.Router) {
-			r.Post("/register", deps.AuthHandler.RegisterAnonymous)
-			r.Post("/refresh", deps.AuthHandler.Refresh)
+			r.With(middleware.RateLimit(5, time.Hour)).Post("/register", deps.AuthHandler.RegisterAnonymous)
+			r.With(middleware.RateLimit(10, time.Minute)).Post("/refresh", deps.AuthHandler.Refresh)
 
 			r.Group(func(r chi.Router) {
 				r.Use(middleware.Auth(deps.TokenManager))
@@ -43,6 +44,7 @@ func New(deps Deps) chi.Router {
 		})
 
 		r.Group(func(r chi.Router) {
+			r.Use(middleware.RateLimit(100, time.Minute))
 			r.Use(middleware.Auth(deps.TokenManager))
 			r.Route("/coffee-beans", func(r chi.Router) {
 				r.Get("/", deps.CoffeeBeansHandler.List)


### PR DESCRIPTION
## Overview

- `go-chi/httprate` を使用したIPベースのレート制限ミドルウェアを導入
- 認証エンドポイント: `/auth/register` 5回/時、`/auth/refresh` 10回/分
- 一般APIエンドポイント: `/coffee-beans` グループ 100回/分
- レート超過時に `429 Too Many Requests` + 標準JSONエラーレスポンス

## Reference

Closes #55

## Debug List

- [ ] レート制限超過時の429レスポンス確認
- [ ] 各エンドポイントの制限値が適切か確認

## Review Deadline