### PR TITLE
feat(frontend): クイックボタンをユーザー設定の1杯量に基づいて動的生成

### DIFF
--- a/frontend/app/(tabs)/beans/[id].tsx
+++ b/frontend/app/(tabs)/beans/[id].tsx
@@ -15,6 +15,7 @@ import { Feather } from "@expo/vector-icons";
 import { useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
 import { beansApi } from "../../../src/api/beans";
 import { usagesApi } from "../../../src/api/usages";
+import { useAuthStore } from "../../../src/stores/auth";
 import { showApiError } from "../../../src/utils/errorHandler";
 import type { CoffeeBean, RoastLevel, RoastDetail, UsageHistory } from "../../../src/types/api";
 import { colors, typography, spacing, radius, shadows, getStockColor, formStyles } from "@/theme";
@@ -23,15 +24,15 @@ import { ChipSelector } from "../../../src/components/ChipSelector";
 import { FormInput } from "../../../src/components/FormInput";
 import { validateBeanForm } from "../../../src/utils/validation";
 
-const USAGE_PRESETS = [
-  { grams: 15, label: "1杯分" },
-  { grams: 20, label: "少し多め" },
-  { grams: 30, label: "2杯分" },
-];
-
 export default function BeanDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
+  const user = useAuthStore((s) => s.user);
+  const gramsPerCup = user?.grams_per_cup ?? 15;
+  const usagePresets = [
+    { grams: gramsPerCup, label: "1杯分" },
+    { grams: gramsPerCup * 2, label: "2杯分" },
+  ];
   const [bean, setBean] = useState<CoffeeBean | null>(null);
   const [loading, setLoading] = useState(true);
   const [editing, setEditing] = useState(false);
@@ -375,7 +376,7 @@ export default function BeanDetailScreen() {
               <Text style={styles.sectionTitle}>使用記録</Text>
 
               <View style={styles.presetRow}>
-                {USAGE_PRESETS.map((preset, index) => (
+                {usagePresets.map((preset, index) => (
                   <TouchableOpacity
                     key={preset.grams}
                     style={[


### PR DESCRIPTION
## Overview

- ハードコードのプリセット(15g/20g/30g)を削除し、ユーザー設定の `grams_per_cup` から1杯分・2杯分を動的生成
- 手動入力欄はそのまま維持

## Reference

Closes #66

## Debug List

- [ ] プロフィール画面で `grams_per_cup` を変更し、豆詳細画面のクイックボタンが連動して変わることを確認
- [ ] クイックボタンタップで正しいグラム数が記録されることを確認
- [ ] 在庫不足時にエラーが表示されることを確認

## Review Deadline