### PR TITLE
fix(frontend): ログアウト機能を削除し匿名ユーザートークンの破壊を防止

### DIFF
--- a/frontend/app/(tabs)/profile.tsx
+++ b/frontend/app/(tabs)/profile.tsx
@@ -9,7 +9,7 @@ import { showApiError } from "../../src/utils/errorHandler";
 import { colors, typography, spacing, radius, shadows } from "@/theme";
 
 export default function ProfileScreen() {
-  const { user, logout, setUser } = useAuthStore();
+  const { user, setUser } = useAuthStore();
   const [editingGrams, setEditingGrams] = useState(false);
   const [gramsInput, setGramsInput] = useState("");
   const [saving, setSaving] = useState(false);
@@ -20,17 +20,6 @@ export default function ProfileScreen() {
       beansApi.list(1000, 0).then(r => setBeanCount(r.beans.length)).catch(() => {});
     }, [])
   );
-
-  const handleLogout = () => {
-    Alert.alert("ログアウト", "ログアウトしますか？", [
-      { text: "キャンセル", style: "cancel" },
-      {
-        text: "ログアウト",
-        style: "destructive",
-        onPress: () => logout(),
-      },
-    ]);
-  };
 
   const handleStartEditGrams = () => {
     setGramsInput(String(user?.grams_per_cup ?? 15));
@@ -130,9 +119,6 @@ export default function ProfileScreen() {
         </TouchableOpacity>
       </View>
 
-      <TouchableOpacity onPress={handleLogout}>
-        <Text style={styles.logoutText}>ログアウト</Text>
-      </TouchableOpacity>
     </View>
   );
 }
@@ -269,10 +255,4 @@ const styles = StyleSheet.create({
     color: colors.textSecondary,
   },
   buttonDisabled: { opacity: 0.6 },
-  logoutText: {
-    ...typography.bodyMedium,
-    color: colors.danger,
-    textAlign: "center",
-    marginTop: spacing["4xl"],
-  },
 });

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout() {
           useAuthStore.setState({ user });
         })
         .catch(() => {
-          useAuthStore.getState().logout();
+          console.warn("getMe failed; keeping stored tokens for retry");
         });
     }
   }, [isLoading, isAuthenticated, accessToken]);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -8,7 +8,7 @@ async function request<T>(
   path: string,
   options: RequestInit = {}
 ): Promise<T> {
-  const { accessToken, refreshToken, setTokens, logout } = useAuthStore.getState();
+  const { accessToken, refreshToken, setTokens } = useAuthStore.getState();
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -38,7 +38,6 @@ async function request<T>(
         res = await fetch(`${API_BASE}${path}`, { ...options, headers });
       }
     } else {
-      await logout();
       throw new ApiError("UNAUTHORIZED", "セッションが切れました。再ログインしてください。");
     }
   }


### PR DESCRIPTION
## Summary
Closes #107

- プロフィール画面からログアウトボタン・`handleLogout`関数・`logoutText`スタイルを削除
- `frontend/src/api/client.ts`: リフレッシュトークン失敗時の`logout()`呼び出しを削除し、SecureStoreのトークンを保持
- `frontend/app/_layout.tsx`: `getMe()`失敗時の`logout()`呼び出しを`console.warn`に変更

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 53 existing frontend tests pass
- [ ] プロフィール画面にログアウトボタンが表示されないことを確認
- [ ] リフレッシュトークン失敗時にローカルトークンが削除されないことを確認
- [ ] getMe失敗時にローカルトークンが削除されないことを確認