### PR TITLE
test(frontend): stores・componentsのテストを追加しclient.testを修正

### DIFF
--- a/.claude/rules/frontend-testing.md
+++ b/.claude/rules/frontend-testing.md
@@ -1,0 +1,146 @@
+---
+paths:
+  - "frontend/src/**/*.test.ts"
+  - "frontend/src/**/*.test.tsx"
+---
+
+# フロントエンド テスト方針
+
+## テストレイヤーと対象
+
+| レイヤー | 対象 | テストツール | 方針 |
+|----------|------|-------------|------|
+| **Unit** | utils, constants, 純粋関数 | Jest | 入出力のみ検証 |
+| **Hook** | custom hooks | `renderHook` + `act` + mock | API層をモック、状態遷移を検証 |
+| **Store** | Zustand store | `renderHook` or 直接呼び出し | SecureStoreはjest.setupでモック済み、状態変更を検証 |
+| **Component** | 再利用コンポーネント | `render` (@testing-library/react-native) | props→表示・イベント→コールバック呼び出しを検証 |
+
+### テスト対象外
+
+- **API wrappers** (`api/beans.ts`, `api/auth.ts` 等): `api/client.ts`への薄い委譲のみでロジックなし。`client.test.ts`でカバー済み
+- **画面コンポーネント** (`app/` 配下): モック量が多くメンテコスト高。hooks層テストで間接カバー。必要時に段階的追加
+- **型定義** (`types/`): 実行時ロジックなし
+- **定数・テーマ** (`theme/colors.ts`, `constants/` 等): 定数定義のみ
+
+## テストファイル配置
+
+- ソースと同階層の `__tests__/` ディレクトリに配置
+- 命名規則: `{対象ファイル名}.test.ts` (`.tsx` はJSXを含む場合)
+
+```
+src/
+├── hooks/
+│   ├── __tests__/
+│   │   └── useBeansList.test.ts
+│   └── useBeansList.ts
+├── components/
+│   ├── __tests__/
+│   │   └── FormInput.test.tsx
+│   └── FormInput.tsx
+```
+
+## テストの書き方ルール
+
+### 共通
+
+- テスト名は日本語で記述
+- `beforeEach(() => jest.clearAllMocks())` でモック状態をリセット
+- 外部依存（API, SecureStore等）のみモック。内部ロジックはモックしない
+
+### Hook テスト テンプレート
+
+```typescript
+import { renderHook, act } from "@testing-library/react-native";
+import { useXxx } from "@/hooks/useXxx";
+import { xxxApi } from "@/api/xxx";
+import { showApiError } from "@/utils/errorHandler";
+
+jest.mock("@/api/xxx");
+jest.mock("@/utils/errorHandler");
+
+const mockMethod = xxxApi.method as jest.MockedFunction<typeof xxxApi.method>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("useXxx", () => {
+  it("呼び出し時にXxxを実行する", async () => {
+    mockMethod.mockResolvedValueOnce(fakeData);
+
+    const { result } = renderHook(() => useXxx());
+
+    await act(async () => {
+      await result.current.someAction();
+    });
+
+    expect(result.current.state).toEqual(expected);
+  });
+});
+```
+
+### Component テスト テンプレート
+
+```tsx
+import { render, fireEvent } from "@testing-library/react-native";
+import { XxxComponent } from "@/components/XxxComponent";
+
+describe("XxxComponent", () => {
+  const defaultProps = {
+    // required props with sensible defaults
+  };
+
+  it("ラベルテキストを表示する", () => {
+    const { getByText } = render(<XxxComponent {...defaultProps} />);
+    expect(getByText("expected text")).toBeTruthy();
+  });
+
+  it("押下時にonXxxが呼ばれる", () => {
+    const onXxx = jest.fn();
+    const { getByText } = render(
+      <XxxComponent {...defaultProps} onXxx={onXxx} />
+    );
+
+    fireEvent.press(getByText("button text"));
+    expect(onXxx).toHaveBeenCalledWith(expectedArg);
+  });
+});
+```
+
+### Store テスト テンプレート
+
+```typescript
+import { useAuthStore } from "@/stores/auth";
+import * as SecureStore from "expo-secure-store";
+
+// jest.setupでSecureStoreはモック済み
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Zustand storeをリセット
+  useAuthStore.setState({
+    user: null,
+    accessToken: null,
+    refreshToken: null,
+    isLoading: true,
+    isAuthenticated: false,
+  });
+});
+
+describe("useAuthStore", () => {
+  it("setAuthでトークンを保存し状態を更新する", async () => {
+    await useAuthStore.getState().setAuth(fakeUser, "access", "refresh");
+
+    const state = useAuthStore.getState();
+    expect(state.isAuthenticated).toBe(true);
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith("access_token", "access");
+  });
+});
+```
+
+## アサーション方針
+
+- 状態オブジェクト全体の比較を優先（`toEqual`）
+- フィールド個別の `toBe` は状態遷移の検証（loading, refreshing等）に限定
+- コンポーネントテストでは `getByText` / `getByTestId` で要素の存在確認、`fireEvent` でインタラクション検証
+- スナップショットテストは使わない（壊れやすくレビューしにくい）

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -112,7 +112,7 @@ describe("token refresh on 401", () => {
     expect(retryCall[1].headers.Authorization).toBe("Bearer new-access");
   });
 
-  it("logs out and throws on refresh failure", async () => {
+  it("リフレッシュ失敗時にエラーをスローしトークンを保持する", async () => {
     useAuthStore.setState({
       accessToken: "expired-token",
       refreshToken: "invalid-refresh",
@@ -130,8 +130,8 @@ describe("token refresh on 401", () => {
 
     await expect(api.get("/beans")).rejects.toThrow("セッションが切れました");
 
-    // Store should be logged out
-    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+    // logout()は削除済みのため、トークンは保持される
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
   });
 });
 

--- a/frontend/src/components/__tests__/ChipSelector.test.tsx
+++ b/frontend/src/components/__tests__/ChipSelector.test.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+import { ChipSelector } from "../ChipSelector";
+
+const items = [
+  { label: "浅煎り", value: "light" },
+  { label: "中煎り", value: "medium" },
+  { label: "深煎り", value: "dark" },
+];
+
+describe("ChipSelector", () => {
+  it("全てのチップアイテムを表示する", () => {
+    const { getByText } = render(
+      <ChipSelector items={items} selected="" onSelect={jest.fn()} />
+    );
+    expect(getByText("浅煎り")).toBeTruthy();
+    expect(getByText("中煎り")).toBeTruthy();
+    expect(getByText("深煎り")).toBeTruthy();
+  });
+
+  it("チップ押下時にonSelectが正しい値で呼ばれる", () => {
+    const onSelect = jest.fn();
+    const { getByText } = render(
+      <ChipSelector items={items} selected="" onSelect={onSelect} />
+    );
+    fireEvent.press(getByText("浅煎り"));
+    expect(onSelect).toHaveBeenCalledWith("light");
+  });
+
+  it("別のチップ押下時にonSelectが呼ばれる", () => {
+    const onSelect = jest.fn();
+    const { getByText } = render(
+      <ChipSelector items={items} selected="light" onSelect={onSelect} />
+    );
+    fireEvent.press(getByText("深煎り"));
+    expect(onSelect).toHaveBeenCalledWith("dark");
+  });
+});

--- a/frontend/src/components/__tests__/FormInput.test.tsx
+++ b/frontend/src/components/__tests__/FormInput.test.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+import { FormInput } from "../FormInput";
+
+describe("FormInput", () => {
+  const defaultProps = {
+    label: "豆の名前",
+    value: "",
+    onChangeText: jest.fn(),
+  };
+
+  it("ラベルテキストを表示する", () => {
+    const { getByText } = render(<FormInput {...defaultProps} />);
+    expect(getByText("豆の名前")).toBeTruthy();
+  });
+
+  it("required=trueの場合に必須マークを表示する", () => {
+    const { getByText } = render(
+      <FormInput {...defaultProps} required={true} />
+    );
+    expect(getByText(" *")).toBeTruthy();
+  });
+
+  it("required=falseの場合に必須マークを表示しない", () => {
+    const { queryByText } = render(
+      <FormInput {...defaultProps} required={false} />
+    );
+    expect(queryByText(" *")).toBeNull();
+  });
+
+  it("入力変更時にonChangeTextが呼ばれる", () => {
+    const onChangeText = jest.fn();
+    const { getByDisplayValue } = render(
+      <FormInput {...defaultProps} value="test" onChangeText={onChangeText} />
+    );
+    fireEvent.changeText(getByDisplayValue("test"), "new value");
+    expect(onChangeText).toHaveBeenCalledWith("new value");
+  });
+
+  it("errorが指定されている場合にエラーメッセージを表示する", () => {
+    const { getByText } = render(
+      <FormInput {...defaultProps} error="入力必須です" />
+    );
+    expect(getByText("入力必須です")).toBeTruthy();
+  });
+
+  it("errorが未指定の場合にエラーメッセージを表示しない", () => {
+    const { queryByText } = render(<FormInput {...defaultProps} />);
+    expect(queryByText("入力必須です")).toBeNull();
+  });
+});

--- a/frontend/src/components/__tests__/SkeletonLoader.test.tsx
+++ b/frontend/src/components/__tests__/SkeletonLoader.test.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { BeanListSkeleton } from "../SkeletonLoader";
+
+describe("SkeletonLoader", () => {
+  it("BeanListSkeletonがクラッシュせずにレンダリングされる", () => {
+    expect(() => render(<BeanListSkeleton />)).not.toThrow();
+  });
+});

--- a/frontend/src/stores/__tests__/auth.test.ts
+++ b/frontend/src/stores/__tests__/auth.test.ts
@@ -1,0 +1,113 @@
+import * as SecureStore from "expo-secure-store";
+import { useAuthStore } from "../auth";
+import type { UserResponse } from "../../types/api";
+
+const mockedSecureStore = jest.mocked(SecureStore);
+
+const mockUser: UserResponse = {
+  id: "user-1",
+  name: "testuser",
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+describe("useAuthStore", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAuthStore.setState({
+      user: null,
+      accessToken: null,
+      refreshToken: null,
+      isLoading: true,
+      isAuthenticated: false,
+    });
+  });
+
+  it("setAuthでトークンを保存し認証状態をセットする", async () => {
+    await useAuthStore.getState().setAuth(mockUser, "access-123", "refresh-456");
+
+    expect(mockedSecureStore.setItemAsync).toHaveBeenCalledWith("access_token", "access-123");
+    expect(mockedSecureStore.setItemAsync).toHaveBeenCalledWith("refresh_token", "refresh-456");
+
+    const state = useAuthStore.getState();
+    expect(state.user).toEqual(mockUser);
+    expect(state.accessToken).toBe("access-123");
+    expect(state.refreshToken).toBe("refresh-456");
+    expect(state.isAuthenticated).toBe(true);
+  });
+
+  it("setTokensでユーザーを変更せずトークンのみ更新する", async () => {
+    await useAuthStore.getState().setTokens("new-access", "new-refresh");
+
+    expect(mockedSecureStore.setItemAsync).toHaveBeenCalledWith("access_token", "new-access");
+    expect(mockedSecureStore.setItemAsync).toHaveBeenCalledWith("refresh_token", "new-refresh");
+
+    const state = useAuthStore.getState();
+    expect(state.accessToken).toBe("new-access");
+    expect(state.refreshToken).toBe("new-refresh");
+    expect(state.user).toBeNull();
+  });
+
+  it("setUserでユーザーのみ更新する", () => {
+    useAuthStore.getState().setUser(mockUser);
+
+    const state = useAuthStore.getState();
+    expect(state.user).toEqual(mockUser);
+    expect(state.accessToken).toBeNull();
+    expect(state.refreshToken).toBeNull();
+  });
+
+  it("logoutでSecureStoreからトークンを削除し状態をリセットする", async () => {
+    useAuthStore.setState({
+      user: mockUser,
+      accessToken: "access-123",
+      refreshToken: "refresh-456",
+      isAuthenticated: true,
+    });
+
+    await useAuthStore.getState().logout();
+
+    expect(mockedSecureStore.deleteItemAsync).toHaveBeenCalledWith("access_token");
+    expect(mockedSecureStore.deleteItemAsync).toHaveBeenCalledWith("refresh_token");
+
+    const state = useAuthStore.getState();
+    expect(state.user).toBeNull();
+    expect(state.accessToken).toBeNull();
+    expect(state.refreshToken).toBeNull();
+    expect(state.isAuthenticated).toBe(false);
+  });
+
+  it("loadStoredTokensでトークンが存在する場合に認証状態を復元する", async () => {
+    mockedSecureStore.getItemAsync.mockImplementation(async (key) => {
+      if (key === "access_token") return "stored-access";
+      if (key === "refresh_token") return "stored-refresh";
+      return null;
+    });
+
+    await useAuthStore.getState().loadStoredTokens();
+
+    const state = useAuthStore.getState();
+    expect(state.accessToken).toBe("stored-access");
+    expect(state.refreshToken).toBe("stored-refresh");
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.isLoading).toBe(false);
+  });
+
+  it("loadStoredTokensでトークンがない場合にisLoadingをfalseにする", async () => {
+    mockedSecureStore.getItemAsync.mockResolvedValue(null);
+
+    await useAuthStore.getState().loadStoredTokens();
+
+    const state = useAuthStore.getState();
+    expect(state.isAuthenticated).toBe(false);
+    expect(state.isLoading).toBe(false);
+  });
+
+  it("loadStoredTokensでエラー時もisLoadingをfalseにする", async () => {
+    mockedSecureStore.getItemAsync.mockRejectedValue(new Error("SecureStore error"));
+
+    await useAuthStore.getState().loadStoredTokens().catch(() => {});
+
+    const state = useAuthStore.getState();
+    expect(state.isLoading).toBe(false);
+  });
+});


### PR DESCRIPTION
## Overview

- auth store（Zustand）のテストを7ケース追加（トークン保存・復元・削除の状態遷移）
- 再利用コンポーネント3つ（FormInput, ChipSelector, SkeletonLoader）のテストを10ケース追加
- logout削除（#109）に伴うclient.testの期待値修正
- フロントエンドテスト方針を `.claude/rules/frontend-testing.md` に策定

## Test Results

- 12 suites, 70 tests all passing
- 既存8ファイル + 新規4ファイル

## Debug List

- [ ] CI pass確認

## Review Deadline