### PR TITLE
refactor(frontend): LoadingSpinnerコンポーネントを抽出

### DIFF
--- a/frontend/app/(tabs)/beans/[id].tsx
+++ b/frontend/app/(tabs)/beans/[id].tsx
@@ -21,6 +21,7 @@ import { colors, typography, spacing, radius, shadows, getStockColor, formStyles
 import { ROAST_LEVELS, ROAST_DETAILS, ROAST_LEVEL_LABELS, ROAST_DETAIL_LABELS } from "@/constants/roastLevels";
 import { ChipSelector } from "@/components/ChipSelector";
 import { FormInput } from "@/components/FormInput";
+import { LoadingSpinner } from "@/components/LoadingSpinner";
 
 export default function BeanDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -82,11 +83,7 @@ export default function BeanDetailScreen() {
   };
 
   if (detail.loading) {
-    return (
-      <View style={styles.center}>
-        <ActivityIndicator size="large" color={colors.primary} />
-      </View>
-    );
+    return <LoadingSpinner />;
   }
 
   if (!detail.bean) return null;
@@ -321,7 +318,6 @@ export default function BeanDetailScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: colors.background },
-  center: { flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: colors.background },
   editBar: {
     alignItems: "flex-end",
     paddingHorizontal: spacing.xl,

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import { Slot, useRouter, useSegments } from "expo-router";
-import { View, ActivityIndicator } from "react-native";
 import { useAuthStore } from "../src/stores/auth";
 import { authApi } from "../src/api/auth";
+import { LoadingSpinner } from "../src/components/LoadingSpinner";
 
 export default function RootLayout() {
   const isLoading = useAuthStore((s) => s.isLoading);
@@ -41,11 +41,7 @@ export default function RootLayout() {
   }, [isMounted, isLoading, isAuthenticated, segments]);
 
   if (isLoading) {
-    return (
-      <View style={{ flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: "#F5F0E8" }}>
-        <ActivityIndicator size="large" color="#4A3F35" />
-      </View>
-    );
+    return <LoadingSpinner />;
   }
 
   return <Slot />;

--- a/frontend/src/components/LoadingSpinner.tsx
+++ b/frontend/src/components/LoadingSpinner.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { ActivityIndicator, StyleSheet, View } from "react-native";
+import { colors } from "@/theme";
+
+interface LoadingSpinnerProps {
+  size?: "small" | "large";
+}
+
+export function LoadingSpinner({ size = "large" }: LoadingSpinnerProps) {
+  return (
+    <View style={styles.center}>
+      <ActivityIndicator testID="loading-spinner" size={size} color={colors.primary} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: colors.background,
+  },
+});

--- a/frontend/src/components/__tests__/LoadingSpinner.test.tsx
+++ b/frontend/src/components/__tests__/LoadingSpinner.test.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { LoadingSpinner } from "../LoadingSpinner";
+
+describe("LoadingSpinner", () => {
+  it("デフォルトでlargeサイズのActivityIndicatorを表示する", () => {
+    const { getByTestId } = render(<LoadingSpinner />);
+    const spinner = getByTestId("loading-spinner");
+    expect(spinner).toBeTruthy();
+    expect(spinner.props.size).toBe("large");
+  });
+
+  it("sizeプロパティでサイズを変更できる", () => {
+    const { getByTestId } = render(<LoadingSpinner size="small" />);
+    const spinner = getByTestId("loading-spinner");
+    expect(spinner.props.size).toBe("small");
+  });
+});


### PR DESCRIPTION
## Overview

- 複数画面で重複していた `ActivityIndicator` + 中央配置 `View` のローディングパターンを `LoadingSpinner` 共通コンポーネントに抽出
- `beans/[id].tsx` と `_layout.tsx` で共通コンポーネントを使用するよう置換
- テスト2件追加

## Reference

Closes #83

## Debug List

- [ ] ローディング表示が正常に動作すること（豆詳細画面、アプリ起動時）

## Review Deadline