### PR TITLE
fix(frontend): 無効トークン時の認証エラーAlertを抑制する

### DIFF
--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -112,7 +112,7 @@ describe("token refresh on 401", () => {
     expect(retryCall[1].headers.Authorization).toBe("Bearer new-access");
   });
 
-  it("リフレッシュ失敗時にエラーをスローしトークンを保持する", async () => {
+  it("リフレッシュ失敗時にログアウトしてエラーをスローする", async () => {
     useAuthStore.setState({
       accessToken: "expired-token",
       refreshToken: "invalid-refresh",
@@ -130,8 +130,33 @@ describe("token refresh on 401", () => {
 
     await expect(api.get("/beans")).rejects.toThrow("セッションが切れました");
 
-    // logout()は削除済みのため、トークンは保持される
-    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+    expect(useAuthStore.getState().accessToken).toBeNull();
+    expect(useAuthStore.getState().refreshToken).toBeNull();
+  });
+
+  it("リフレッシュトークンなしでサーバーがUNAUTHORIZEDを返した場合ログアウトする", async () => {
+    useAuthStore.setState({
+      accessToken: "some-token",
+      refreshToken: null,
+      isAuthenticated: true,
+    });
+
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          success: false,
+          error: { code: "UNAUTHORIZED", message: "認証トークンが必要です" },
+        },
+        401
+      )
+    );
+
+    await expect(api.get("/beans")).rejects.toThrow("認証トークンが必要です");
+
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+    expect(useAuthStore.getState().accessToken).toBeNull();
+    expect(useAuthStore.getState().refreshToken).toBeNull();
   });
 });
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -38,6 +38,7 @@ async function request<T>(
         res = await fetch(`${API_BASE}${path}`, { ...options, headers });
       }
     } else {
+      await useAuthStore.getState().logout();
       throw new ApiError("UNAUTHORIZED", "セッションが切れました。再ログインしてください。");
     }
   }
@@ -48,6 +49,10 @@ async function request<T>(
     json = JSON.parse(text);
   } catch {
     throw new ApiError("PARSE_ERROR", `サーバーエラー (${res.status}): ${text.slice(0, 200)}`);
+  }
+
+  if (!json.success && json.error?.code === "UNAUTHORIZED") {
+    await useAuthStore.getState().logout();
   }
 
   if (!json.success) {

--- a/frontend/src/utils/__tests__/errorHandler.test.ts
+++ b/frontend/src/utils/__tests__/errorHandler.test.ts
@@ -48,4 +48,12 @@ describe("showApiError", () => {
       "カスタムエラーメッセージ",
     );
   });
+
+  it("UNAUTHORIZEDエラーの場合Alertを表示しない", () => {
+    const error = new ApiError("UNAUTHORIZED", "認証トークンが必要です");
+
+    showApiError(error);
+
+    expect(Alert.alert).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/utils/errorHandler.ts
+++ b/frontend/src/utils/errorHandler.ts
@@ -7,6 +7,9 @@ export function showApiError(
   codeMessages?: Record<string, string>,
 ): void {
   if (e instanceof ApiError) {
+    if (e.code === "UNAUTHORIZED") {
+      return;
+    }
     const overridden = codeMessages?.[e.code];
     Alert.alert("エラー", overridden ?? e.message);
   } else {


### PR DESCRIPTION
## Summary

- `client.ts`の`request()`で401確定時（リフレッシュ失敗/リフレッシュトークンなし）に`logout()`を呼ぶようにした
- `errorHandler.ts`の`showApiError()`でUNAUTHORIZEDエラーのAlert表示を抑制した
- 対応するテストを更新・追加（計2件）

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `frontend/src/api/client.ts` | リフレッシュ失敗時とサーバーUNAUTHORIZED応答時に`logout()`を呼ぶ |
| `frontend/src/utils/errorHandler.ts` | UNAUTHORIZEDエラーコードの場合Alertを表示しない |
| `frontend/src/api/__tests__/client.test.ts` | 既存テスト更新 + 新規テスト追加 |
| `frontend/src/utils/__tests__/errorHandler.test.ts` | UNAUTHORIZED抑制テスト追加 |

## Related Issue

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)