### PR TITLE
feat(backend): リフレッシュトークンの有効期限を7日から60日に延長する

### DIFF
--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	AccessTokenDuration  = 1 * time.Hour
-	RefreshTokenDuration = 7 * 24 * time.Hour
+	RefreshTokenDuration = 60 * 24 * time.Hour
 )
 
 // jwtClaims is the internal JWT claims structure.


### PR DESCRIPTION
## Summary

- リフレッシュトークンの有効期限を7日から60日に延長
- 匿名認証・低リスクデータ・トークンローテーション済みのため、セキュリティリスクは許容範囲
- 2ヶ月に1回のアプリ利用でもデータが維持される

## Changes

- `backend/internal/auth/jwt.go`: `RefreshTokenDuration` を `7 * 24 * time.Hour` → `60 * 24 * time.Hour` に変更

## Related Issue

Closes #120

## Acceptance Criteria

- ✅ `RefreshTokenDuration` が `60 * 24 * time.Hour` に変更されている
- ✅ 既存テストが通る

🤖 Generated with Claude Code