### PR TITLE
feat(frontend): 低在庫アラート表示を追加する

### DIFF
--- a/backend/api/openapi.yaml
+++ b/backend/api/openapi.yaml
@@ -457,6 +457,12 @@ components:
           type: integer
           format: int32
           description: "直近7日間の合計消費量 (g)"
+        alert_level:
+          type: string
+          enum:
+            - danger
+            - warning
+          description: "在庫アラートレベル（残日数ベース、アラートなしの場合は省略）"
 
     CoffeeBeanResponse:
       type: object

--- a/backend/internal/api/gen/types.gen.go
+++ b/backend/internal/api/gen/types.gen.go
@@ -13,6 +13,24 @@ const (
 	BearerAuthScopes = "bearerAuth.Scopes"
 )
 
+// Defines values for ConsumptionRateAlertLevel.
+const (
+	Danger  ConsumptionRateAlertLevel = "danger"
+	Warning ConsumptionRateAlertLevel = "warning"
+)
+
+// Valid indicates whether the value is a known member of the ConsumptionRateAlertLevel enum.
+func (e ConsumptionRateAlertLevel) Valid() bool {
+	switch e {
+	case Danger:
+		return true
+	case Warning:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for RoastDetail.
 const (
 	RoastDetailCinnamon RoastDetail = "cinnamon"
@@ -96,6 +114,9 @@ type CoffeeBeanResponse struct {
 
 // ConsumptionRate defines model for ConsumptionRate.
 type ConsumptionRate struct {
+	// AlertLevel 在庫アラートレベル（残日数ベース、アラートなしの場合は省略）
+	AlertLevel *ConsumptionRateAlertLevel `json:"alert_level,omitempty"`
+
 	// DailyConsumptionGrams 1日あたりの消費量 (g)
 	DailyConsumptionGrams *float32 `json:"daily_consumption_grams,omitempty"`
 
@@ -108,6 +129,9 @@ type ConsumptionRate struct {
 	// WeeklyTotalGrams 直近7日間の合計消費量 (g)
 	WeeklyTotalGrams *int32 `json:"weekly_total_grams,omitempty"`
 }
+
+// ConsumptionRateAlertLevel 在庫アラートレベル（残日数ベース、アラートなしの場合は省略）
+type ConsumptionRateAlertLevel string
 
 // CreateBeanRequest defines model for CreateBeanRequest.
 type CreateBeanRequest struct {

--- a/backend/internal/api/handlers/coffee_beans_handler.go
+++ b/backend/internal/api/handlers/coffee_beans_handler.go
@@ -44,6 +44,10 @@ func toCoffeeBeanResponse(b *coffeebean.CoffeeBean, cr coffeebean.ConsumptionRat
 	if cr.WeeklyTotal() != nil {
 		resp.ConsumptionRate.WeeklyTotalGrams = cr.WeeklyTotal()
 	}
+	if al := cr.AlertLevel(); al != "" {
+		s := gen.ConsumptionRateAlertLevel(al)
+		resp.ConsumptionRate.AlertLevel = &s
+	}
 	if b.RoastDetail() != nil {
 		rd := gen.RoastDetail(b.RoastDetail().String())
 		resp.RoastDetail = &rd

--- a/backend/internal/domain/coffeebean/consumption_rate.go
+++ b/backend/internal/domain/coffeebean/consumption_rate.go
@@ -2,12 +2,22 @@ package coffeebean
 
 import "math"
 
+// AlertLevel represents the stock alert severity based on remaining days.
+type AlertLevel string
+
+const (
+	AlertLevelDanger  AlertLevel = "danger"
+	AlertLevelWarning AlertLevel = "warning"
+	AlertLevelNone    AlertLevel = ""
+)
+
 // ConsumptionRate holds consumption metrics for a coffee bean.
 type ConsumptionRate struct {
 	remainingCups    int32
 	remainingDays    *int32
 	dailyConsumption *float64
 	weeklyTotal      *int32
+	alertLevel       AlertLevel
 }
 
 // NewConsumptionRate calculates consumption rate from stock, grams per cup, and weekly usage.
@@ -24,6 +34,7 @@ func NewConsumptionRate(currentStock, gramsPerCup int32, weeklyUsage *int32) Con
 			remainingDays:    nil,
 			dailyConsumption: nil,
 			weeklyTotal:      nil,
+			alertLevel:       AlertLevelNone,
 		}
 	}
 
@@ -36,10 +47,22 @@ func NewConsumptionRate(currentStock, gramsPerCup int32, weeklyUsage *int32) Con
 		remainingDays:    &days,
 		dailyConsumption: &daily,
 		weeklyTotal:      &wt,
+		alertLevel:       calcAlertLevel(days),
 	}
+}
+
+func calcAlertLevel(remainingDays int32) AlertLevel {
+	if remainingDays <= 3 {
+		return AlertLevelDanger
+	}
+	if remainingDays <= 7 {
+		return AlertLevelWarning
+	}
+	return AlertLevelNone
 }
 
 func (c ConsumptionRate) RemainingCups() int32       { return c.remainingCups }
 func (c ConsumptionRate) RemainingDays() *int32      { return c.remainingDays }
 func (c ConsumptionRate) DailyConsumption() *float64 { return c.dailyConsumption }
 func (c ConsumptionRate) WeeklyTotal() *int32        { return c.weeklyTotal }
+func (c ConsumptionRate) AlertLevel() AlertLevel     { return c.alertLevel }

--- a/backend/internal/domain/coffeebean/consumption_rate_test.go
+++ b/backend/internal/domain/coffeebean/consumption_rate_test.go
@@ -15,6 +15,7 @@ type consumptionRateResult struct {
 	RemainingDays    *int32
 	DailyConsumption *float64
 	WeeklyTotal      *int32
+	AlertLevel       coffeebean.AlertLevel
 }
 
 func toResult(cr coffeebean.ConsumptionRate) consumptionRateResult {
@@ -23,6 +24,7 @@ func toResult(cr coffeebean.ConsumptionRate) consumptionRateResult {
 		RemainingDays:    cr.RemainingDays(),
 		DailyConsumption: cr.DailyConsumption(),
 		WeeklyTotal:      cr.WeeklyTotal(),
+		AlertLevel:       cr.AlertLevel(),
 	}
 }
 
@@ -44,6 +46,7 @@ func TestNewConsumptionRate(t *testing.T) {
 				RemainingDays:    ptr(int32(10)),
 				DailyConsumption: ptr(15.0),
 				WeeklyTotal:      ptr(int32(105)),
+				AlertLevel:       coffeebean.AlertLevelNone,
 			},
 		},
 		"在庫0gの場合": {
@@ -55,6 +58,7 @@ func TestNewConsumptionRate(t *testing.T) {
 				RemainingDays:    ptr(int32(0)),
 				DailyConsumption: ptr(15.0),
 				WeeklyTotal:      ptr(int32(105)),
+				AlertLevel:       coffeebean.AlertLevelDanger,
 			},
 		},
 		"週間使用量が0の場合_予測フィールドはnil": {
@@ -66,6 +70,7 @@ func TestNewConsumptionRate(t *testing.T) {
 				RemainingDays:    nil,
 				DailyConsumption: nil,
 				WeeklyTotal:      nil,
+				AlertLevel:       coffeebean.AlertLevelNone,
 			},
 		},
 		"週間使用データがnilの場合_予測フィールドはnil": {
@@ -77,6 +82,55 @@ func TestNewConsumptionRate(t *testing.T) {
 				RemainingDays:    nil,
 				DailyConsumption: nil,
 				WeeklyTotal:      nil,
+				AlertLevel:       coffeebean.AlertLevelNone,
+			},
+		},
+		"残日数3日以下の場合_アラートはdanger": {
+			currentStock: 45,
+			gramsPerCup:  15,
+			weeklyUsage:  ptr(int32(105)),
+			want: consumptionRateResult{
+				RemainingCups:    3,
+				RemainingDays:    ptr(int32(3)),
+				DailyConsumption: ptr(15.0),
+				WeeklyTotal:      ptr(int32(105)),
+				AlertLevel:       coffeebean.AlertLevelDanger,
+			},
+		},
+		"残日数4日の場合_アラートはwarning": {
+			currentStock: 60,
+			gramsPerCup:  15,
+			weeklyUsage:  ptr(int32(105)),
+			want: consumptionRateResult{
+				RemainingCups:    4,
+				RemainingDays:    ptr(int32(4)),
+				DailyConsumption: ptr(15.0),
+				WeeklyTotal:      ptr(int32(105)),
+				AlertLevel:       coffeebean.AlertLevelWarning,
+			},
+		},
+		"残日数7日の場合_アラートはwarning": {
+			currentStock: 105,
+			gramsPerCup:  15,
+			weeklyUsage:  ptr(int32(105)),
+			want: consumptionRateResult{
+				RemainingCups:    7,
+				RemainingDays:    ptr(int32(7)),
+				DailyConsumption: ptr(15.0),
+				WeeklyTotal:      ptr(int32(105)),
+				AlertLevel:       coffeebean.AlertLevelWarning,
+			},
+		},
+		"残日数8日の場合_アラートなし": {
+			currentStock: 120,
+			gramsPerCup:  15,
+			weeklyUsage:  ptr(int32(105)),
+			want: consumptionRateResult{
+				RemainingCups:    8,
+				RemainingDays:    ptr(int32(8)),
+				DailyConsumption: ptr(15.0),
+				WeeklyTotal:      ptr(int32(105)),
+				AlertLevel:       coffeebean.AlertLevelNone,
 			},
 		},
 	}

--- a/frontend/app/(tabs)/beans/[id].tsx
+++ b/frontend/app/(tabs)/beans/[id].tsx
@@ -17,7 +17,7 @@ import { useAuthStore } from "@/stores/auth";
 import { useBeanDetail } from "@/hooks/useBeanDetail";
 import { useBeanForm } from "@/hooks/useBeanForm";
 import { useUsageTracking } from "@/hooks/useUsageTracking";
-import { colors, typography, spacing, radius, shadows, getStockAlertLevel, getAlertAccentColor, formStyles } from "@/theme";
+import { colors, typography, spacing, radius, shadows, getAlertAccentColor, formStyles } from "@/theme";
 import { Button } from "@/components/Button";
 import { ROAST_LEVELS, ROAST_DETAILS, ROAST_LEVEL_LABELS, ROAST_DETAIL_LABELS } from "@/constants/roastLevels";
 import { ChipSelector } from "@/components/ChipSelector";
@@ -90,8 +90,8 @@ export default function BeanDetailScreen() {
   if (!detail.bean) return null;
 
   const bean = detail.bean;
-  const alertLevel = getStockAlertLevel(bean.consumption_rate.remaining_days);
-  const accentColor = getAlertAccentColor(bean.consumption_rate.remaining_days);
+  const alertLevel = bean.consumption_rate.alert_level;
+  const accentColor = getAlertAccentColor(alertLevel, bean.consumption_rate.remaining_days);
 
   const roastDisplayText = (() => {
     const levelLabel = ROAST_LEVEL_LABELS[bean.roast_level];

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -11,7 +11,7 @@ import {
 import { useFocusEffect, useRouter } from "expo-router";
 import { MaterialCommunityIcons, Ionicons } from "@expo/vector-icons";
 import type { CoffeeBean } from "../../src/types/api";
-import { colors, typography, spacing, radius, shadows, getStockAlertLevel, getAlertAccentColor } from "@/theme";
+import { colors, typography, spacing, radius, shadows, getAlertAccentColor } from "@/theme";
 import { ROAST_LEVEL_LABELS } from "../../src/constants/roastLevels";
 import { BeanListSkeleton } from "../../src/components/SkeletonLoader";
 import { useBeansList } from "@/hooks/useBeansList";
@@ -43,8 +43,8 @@ export default function BeansListScreen() {
   );
 
   const renderBean = ({ item, index }: { item: CoffeeBean; index: number }) => {
-    const alertLevel = getStockAlertLevel(item.consumption_rate.remaining_days);
-    const accentColor = getAlertAccentColor(item.consumption_rate.remaining_days);
+    const alertLevel = item.consumption_rate.alert_level;
+    const accentColor = getAlertAccentColor(alertLevel, item.consumption_rate.remaining_days);
     const anim = getAnimatedValue(index);
     return (
       <Animated.View style={{ opacity: anim, transform: [{ translateY: anim.interpolate({ inputRange: [0, 1], outputRange: [8, 0] }) }] }}>

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -11,20 +11,12 @@ export const getStockColor = (stock: number) => {
   return colors.success;
 };
 
-export const getStockAlertLevel = (
-  remainingDays: number | null | undefined,
-): "danger" | "warning" | null => {
-  if (remainingDays == null) return null;
-  if (remainingDays <= 3) return "danger";
-  if (remainingDays <= 7) return "warning";
-  return null;
-};
-
 export const getAlertAccentColor = (
-  remainingDays: number | null | undefined,
+  alertLevel: "danger" | "warning" | undefined,
+  remainingDays: number | undefined,
 ): string => {
-  if (remainingDays == null) return colors.accent;
-  if (remainingDays <= 3) return colors.danger;
-  if (remainingDays <= 7) return colors.warning;
-  return colors.success;
+  if (alertLevel === "danger") return colors.danger;
+  if (alertLevel === "warning") return colors.warning;
+  if (remainingDays != null) return colors.success;
+  return colors.accent;
 };

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -214,6 +214,11 @@ export interface components {
              * @description 直近7日間の合計消費量 (g)
              */
             weekly_total_grams?: number;
+            /**
+             * @description 在庫アラートレベル（残日数ベース、アラートなしの場合は省略）
+             * @enum {string}
+             */
+            alert_level?: "danger" | "warning";
         };
         CoffeeBeanResponse: {
             /** Format: uuid */


### PR DESCRIPTION
## Overview

- 残日数に応じたカード背景ティント・バッジ表示で低在庫の豆を視覚的に強調
- 一覧画面: 背景色変更 + 「買い足し時」「そろそろ」バッジ + アクセントバー/ストックサークル色を残日数ベースに統一
- 詳細画面: 消費カードの枠・背景色を残日数に応じて変更
- アラート閾値(≤3日=danger, ≤7日=warning)はバックエンドのドメイン層で管理し、APIレスポンスの`alert_level`フィールドで返却

## Reference

Closes #68

## Debug List

- [ ] 残日数3日以下の豆: 赤系背景 + 「買い足し時」バッジ表示
- [ ] 残日数4-7日の豆: オレンジ系背景 + 「そろそろ」バッジ表示
- [ ] 残日数8日以上の豆: 通常表示（緑アクセント）
- [ ] データ不足の豆: アラートなし（アクセント色）
- [ ] 詳細画面の消費カード色分け確認
- [ ] APIレスポンスにalert_levelが含まれることを確認

## Review Deadline