### PR TITLE
refactor: notification_enabled機能を削除する

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,6 @@ DELETE /api/v1/usage-history/:id       # 削除
 - password_hash (VARCHAR)
 - name (VARCHAR)
 - low_stock_threshold (INTEGER, デフォルト: 100g)
-- notification_enabled (BOOLEAN, デフォルト: true)
 - created_at, updated_at, deleted_at
 
 #### coffee_beans

--- a/backend/api/openapi.yaml
+++ b/backend/api/openapi.yaml
@@ -356,8 +356,6 @@ components:
         low_stock_threshold:
           type: integer
           format: int32
-        notification_enabled:
-          type: boolean
         grams_per_cup:
           type: integer
           format: int32
@@ -407,8 +405,6 @@ components:
         low_stock_threshold:
           type: integer
           format: int32
-        notification_enabled:
-          type: boolean
         grams_per_cup:
           type: integer
           format: int32

--- a/backend/internal/api/gen/types.gen.go
+++ b/backend/internal/api/gen/types.gen.go
@@ -217,9 +217,8 @@ type UpdateBeanRequest struct {
 
 // UpdateUserRequest defines model for UpdateUserRequest.
 type UpdateUserRequest struct {
-	GramsPerCup         *int32 `json:"grams_per_cup,omitempty"`
-	LowStockThreshold   *int32 `json:"low_stock_threshold,omitempty"`
-	NotificationEnabled *bool  `json:"notification_enabled,omitempty"`
+	GramsPerCup       *int32 `json:"grams_per_cup,omitempty"`
+	LowStockThreshold *int32 `json:"low_stock_threshold,omitempty"`
 }
 
 // UsageHistoryResponse defines model for UsageHistoryResponse.
@@ -234,13 +233,12 @@ type UsageHistoryResponse struct {
 
 // UserResponse defines model for UserResponse.
 type UserResponse struct {
-	CreatedAt           time.Time          `json:"created_at"`
-	GramsPerCup         *int32             `json:"grams_per_cup,omitempty"`
-	Id                  openapi_types.UUID `json:"id"`
-	LowStockThreshold   *int32             `json:"low_stock_threshold,omitempty"`
-	Name                *string            `json:"name,omitempty"`
-	NotificationEnabled *bool              `json:"notification_enabled,omitempty"`
-	UpdatedAt           *time.Time         `json:"updated_at,omitempty"`
+	CreatedAt         time.Time          `json:"created_at"`
+	GramsPerCup       *int32             `json:"grams_per_cup,omitempty"`
+	Id                openapi_types.UUID `json:"id"`
+	LowStockThreshold *int32             `json:"low_stock_threshold,omitempty"`
+	Name              *string            `json:"name,omitempty"`
+	UpdatedAt         *time.Time         `json:"updated_at,omitempty"`
 }
 
 // ListBeansParams defines parameters for ListBeans.

--- a/backend/internal/api/handlers/auth_handler.go
+++ b/backend/internal/api/handlers/auth_handler.go
@@ -30,9 +30,6 @@ func toUserResponse(u *user.User) gen.UserResponse {
 	if threshold := u.LowStockThreshold(); threshold != 0 {
 		resp.LowStockThreshold = &threshold
 	}
-	if enabled := u.NotificationEnabled(); enabled {
-		resp.NotificationEnabled = &enabled
-	}
 	if gpc := u.GramsPerCup().Value(); gpc != 0 {
 		resp.GramsPerCup = &gpc
 	}
@@ -115,10 +112,9 @@ func (h *AuthHandler) UpdateMe(w http.ResponseWriter, r *http.Request) {
 	}
 
 	output, err := h.authService.UpdateMe(r.Context(), usecase.UpdateMeInput{
-		UserID:              userID,
-		GramsPerCup:         req.GramsPerCup,
-		LowStockThreshold:   req.LowStockThreshold,
-		NotificationEnabled: req.NotificationEnabled,
+		UserID:            userID,
+		GramsPerCup:       req.GramsPerCup,
+		LowStockThreshold: req.LowStockThreshold,
 	})
 	if err != nil {
 		handleDomainError(w, err, "ユーザーが見つかりません")

--- a/backend/internal/database/models.go
+++ b/backend/internal/database/models.go
@@ -53,14 +53,13 @@ type UsageHistory struct {
 }
 
 type User struct {
-	ID                  pgtype.UUID        `json:"id"`
-	Email               pgtype.Text        `json:"email"`
-	PasswordHash        pgtype.Text        `json:"password_hash"`
-	Name                pgtype.Text        `json:"name"`
-	LowStockThreshold   int32              `json:"low_stock_threshold"`
-	NotificationEnabled bool               `json:"notification_enabled"`
-	GramsPerCup         int32              `json:"grams_per_cup"`
-	CreatedAt           pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt           pgtype.Timestamptz `json:"updated_at"`
-	DeletedAt           pgtype.Timestamptz `json:"deleted_at"`
+	ID                pgtype.UUID        `json:"id"`
+	Email             pgtype.Text        `json:"email"`
+	PasswordHash      pgtype.Text        `json:"password_hash"`
+	Name              pgtype.Text        `json:"name"`
+	LowStockThreshold int32              `json:"low_stock_threshold"`
+	GramsPerCup       int32              `json:"grams_per_cup"`
+	CreatedAt         pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt         pgtype.Timestamptz `json:"updated_at"`
+	DeletedAt         pgtype.Timestamptz `json:"deleted_at"`
 }

--- a/backend/internal/database/queries.sql.go
+++ b/backend/internal/database/queries.sql.go
@@ -61,28 +61,22 @@ func (q *Queries) CountUsageHistoriesByUserID(ctx context.Context, userID pgtype
 
 const createAnonymousUser = `-- name: CreateAnonymousUser :one
 
-INSERT INTO users (id, low_stock_threshold, notification_enabled, grams_per_cup)
-VALUES ($1, $2, $3, $4)
-RETURNING id, email, password_hash, name, low_stock_threshold, notification_enabled, grams_per_cup, created_at, updated_at, deleted_at
+INSERT INTO users (id, low_stock_threshold, grams_per_cup)
+VALUES ($1, $2, $3)
+RETURNING id, email, password_hash, name, low_stock_threshold, grams_per_cup, created_at, updated_at, deleted_at
 `
 
 type CreateAnonymousUserParams struct {
-	ID                  pgtype.UUID `json:"id"`
-	LowStockThreshold   int32       `json:"low_stock_threshold"`
-	NotificationEnabled bool        `json:"notification_enabled"`
-	GramsPerCup         int32       `json:"grams_per_cup"`
+	ID                pgtype.UUID `json:"id"`
+	LowStockThreshold int32       `json:"low_stock_threshold"`
+	GramsPerCup       int32       `json:"grams_per_cup"`
 }
 
 // ============================================================================
 // Users Queries
 // ============================================================================
 func (q *Queries) CreateAnonymousUser(ctx context.Context, arg CreateAnonymousUserParams) (User, error) {
-	row := q.db.QueryRow(ctx, createAnonymousUser,
-		arg.ID,
-		arg.LowStockThreshold,
-		arg.NotificationEnabled,
-		arg.GramsPerCup,
-	)
+	row := q.db.QueryRow(ctx, createAnonymousUser, arg.ID, arg.LowStockThreshold, arg.GramsPerCup)
 	var i User
 	err := row.Scan(
 		&i.ID,
@@ -90,7 +84,6 @@ func (q *Queries) CreateAnonymousUser(ctx context.Context, arg CreateAnonymousUs
 		&i.PasswordHash,
 		&i.Name,
 		&i.LowStockThreshold,
-		&i.NotificationEnabled,
 		&i.GramsPerCup,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -576,7 +569,7 @@ func (q *Queries) GetUsageHistoryByID(ctx context.Context, id pgtype.UUID) (Usag
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, email, password_hash, name, low_stock_threshold, notification_enabled, grams_per_cup, created_at, updated_at, deleted_at FROM users
+SELECT id, email, password_hash, name, low_stock_threshold, grams_per_cup, created_at, updated_at, deleted_at FROM users
 WHERE id = $1 AND deleted_at IS NULL
 `
 
@@ -589,7 +582,6 @@ func (q *Queries) GetUserByID(ctx context.Context, id pgtype.UUID) (User, error)
 		&i.PasswordHash,
 		&i.Name,
 		&i.LowStockThreshold,
-		&i.NotificationEnabled,
 		&i.GramsPerCup,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -1050,19 +1042,17 @@ UPDATE users
 SET
     name = COALESCE($2, name),
     low_stock_threshold = COALESCE($3, low_stock_threshold),
-    notification_enabled = COALESCE($4, notification_enabled),
-    grams_per_cup = COALESCE($5, grams_per_cup),
+    grams_per_cup = COALESCE($4, grams_per_cup),
     updated_at = CURRENT_TIMESTAMP
 WHERE id = $1 AND deleted_at IS NULL
-RETURNING id, email, password_hash, name, low_stock_threshold, notification_enabled, grams_per_cup, created_at, updated_at, deleted_at
+RETURNING id, email, password_hash, name, low_stock_threshold, grams_per_cup, created_at, updated_at, deleted_at
 `
 
 type UpdateUserParams struct {
-	ID                  pgtype.UUID `json:"id"`
-	Name                pgtype.Text `json:"name"`
-	LowStockThreshold   pgtype.Int4 `json:"low_stock_threshold"`
-	NotificationEnabled pgtype.Bool `json:"notification_enabled"`
-	GramsPerCup         pgtype.Int4 `json:"grams_per_cup"`
+	ID                pgtype.UUID `json:"id"`
+	Name              pgtype.Text `json:"name"`
+	LowStockThreshold pgtype.Int4 `json:"low_stock_threshold"`
+	GramsPerCup       pgtype.Int4 `json:"grams_per_cup"`
 }
 
 func (q *Queries) UpdateUser(ctx context.Context, arg UpdateUserParams) (User, error) {
@@ -1070,7 +1060,6 @@ func (q *Queries) UpdateUser(ctx context.Context, arg UpdateUserParams) (User, e
 		arg.ID,
 		arg.Name,
 		arg.LowStockThreshold,
-		arg.NotificationEnabled,
 		arg.GramsPerCup,
 	)
 	var i User
@@ -1080,7 +1069,6 @@ func (q *Queries) UpdateUser(ctx context.Context, arg UpdateUserParams) (User, e
 		&i.PasswordHash,
 		&i.Name,
 		&i.LowStockThreshold,
-		&i.NotificationEnabled,
 		&i.GramsPerCup,
 		&i.CreatedAt,
 		&i.UpdatedAt,

--- a/backend/internal/domain/user/user.go
+++ b/backend/internal/domain/user/user.go
@@ -10,55 +10,52 @@ import (
 )
 
 type User struct {
-	createdAt           time.Time
-	updatedAt           time.Time
-	email               string
-	passwordHash        string
-	name                string
-	lowStockThreshold   int32
-	id                  uuid.UUID
-	gramsPerCup         GramsPerCup
-	notificationEnabled bool
+	createdAt         time.Time
+	updatedAt         time.Time
+	email             string
+	passwordHash      string
+	name              string
+	lowStockThreshold int32
+	id                uuid.UUID
+	gramsPerCup       GramsPerCup
 }
 
 // NewAnonymousUser creates a new anonymous user with default settings.
 func NewAnonymousUser() *User {
 	now := time.Now().UTC()
 	return &User{
-		id:                  uuid.New(),
-		email:               "",
-		passwordHash:        "",
-		name:                "",
-		lowStockThreshold:   100,
-		notificationEnabled: true,
-		gramsPerCup:         DefaultGramsPerCup(),
-		createdAt:           now,
-		updatedAt:           now,
+		id:                uuid.New(),
+		email:             "",
+		passwordHash:      "",
+		name:              "",
+		lowStockThreshold: 100,
+		gramsPerCup:       DefaultGramsPerCup(),
+		createdAt:         now,
+		updatedAt:         now,
 	}
 }
 
 // Reconstruct restores a User from persisted data without validation.
 func Reconstruct(
 	id uuid.UUID, email, passwordHash, name string,
-	lowStockThreshold int32, notificationEnabled bool,
+	lowStockThreshold int32,
 	gramsPerCup GramsPerCup,
 	createdAt, updatedAt time.Time,
 ) *User {
 	return &User{
-		id:                  id,
-		email:               email,
-		passwordHash:        passwordHash,
-		name:                name,
-		lowStockThreshold:   lowStockThreshold,
-		notificationEnabled: notificationEnabled,
-		gramsPerCup:         gramsPerCup,
-		createdAt:           createdAt,
-		updatedAt:           updatedAt,
+		id:                id,
+		email:             email,
+		passwordHash:      passwordHash,
+		name:              name,
+		lowStockThreshold: lowStockThreshold,
+		gramsPerCup:       gramsPerCup,
+		createdAt:         createdAt,
+		updatedAt:         updatedAt,
 	}
 }
 
 // Update modifies the user's settings with validation.
-func (u *User) Update(gramsPerCup, lowStockThreshold *int32, notificationEnabled *bool) error {
+func (u *User) Update(gramsPerCup, lowStockThreshold *int32) error {
 	var errs domain.ValidationErrors
 
 	if gramsPerCup != nil {
@@ -74,9 +71,6 @@ func (u *User) Update(gramsPerCup, lowStockThreshold *int32, notificationEnabled
 	if lowStockThreshold != nil {
 		u.lowStockThreshold = *lowStockThreshold
 	}
-	if notificationEnabled != nil {
-		u.notificationEnabled = *notificationEnabled
-	}
 	if len(errs) > 0 {
 		return errs
 	}
@@ -84,12 +78,11 @@ func (u *User) Update(gramsPerCup, lowStockThreshold *int32, notificationEnabled
 	return nil
 }
 
-func (u *User) ID() uuid.UUID             { return u.id }
-func (u *User) Email() string             { return u.email }
-func (u *User) PasswordHash() string      { return u.passwordHash }
-func (u *User) Name() string              { return u.name }
-func (u *User) LowStockThreshold() int32  { return u.lowStockThreshold }
-func (u *User) NotificationEnabled() bool { return u.notificationEnabled }
-func (u *User) GramsPerCup() GramsPerCup  { return u.gramsPerCup }
-func (u *User) CreatedAt() time.Time      { return u.createdAt }
-func (u *User) UpdatedAt() time.Time      { return u.updatedAt }
+func (u *User) ID() uuid.UUID            { return u.id }
+func (u *User) Email() string            { return u.email }
+func (u *User) PasswordHash() string     { return u.passwordHash }
+func (u *User) Name() string             { return u.name }
+func (u *User) LowStockThreshold() int32 { return u.lowStockThreshold }
+func (u *User) GramsPerCup() GramsPerCup { return u.gramsPerCup }
+func (u *User) CreatedAt() time.Time     { return u.createdAt }
+func (u *User) UpdatedAt() time.Time     { return u.updatedAt }

--- a/backend/internal/repository/user_repository_impl.go
+++ b/backend/internal/repository/user_repository_impl.go
@@ -28,10 +28,9 @@ func (r *userRepository) GetByID(ctx context.Context, id uuid.UUID) (*user.User,
 
 func (r *userRepository) Save(ctx context.Context, u *user.User) error {
 	_, err := r.queries.CreateAnonymousUser(ctx, database.CreateAnonymousUserParams{
-		ID:                  toUUID(u.ID()),
-		LowStockThreshold:   u.LowStockThreshold(),
-		NotificationEnabled: u.NotificationEnabled(),
-		GramsPerCup:         u.GramsPerCup().Value(),
+		ID:                toUUID(u.ID()),
+		LowStockThreshold: u.LowStockThreshold(),
+		GramsPerCup:       u.GramsPerCup().Value(),
 	})
 	return err
 }
@@ -39,13 +38,11 @@ func (r *userRepository) Save(ctx context.Context, u *user.User) error {
 func (r *userRepository) Update(ctx context.Context, u *user.User) error {
 	threshold := u.LowStockThreshold()
 	gpc := u.GramsPerCup().Value()
-	enabled := u.NotificationEnabled()
 
 	_, err := r.queries.UpdateUser(ctx, database.UpdateUserParams{
-		ID:                  toUUID(u.ID()),
-		LowStockThreshold:   pgtype.Int4{Int32: threshold, Valid: true},
-		NotificationEnabled: pgtype.Bool{Bool: enabled, Valid: true},
-		GramsPerCup:         pgtype.Int4{Int32: gpc, Valid: true},
+		ID:                toUUID(u.ID()),
+		LowStockThreshold: pgtype.Int4{Int32: threshold, Valid: true},
+		GramsPerCup:       pgtype.Int4{Int32: gpc, Valid: true},
 	})
 	return err
 }
@@ -69,7 +66,7 @@ func toDomainUser(u database.User) *user.User {
 
 	return user.Reconstruct(
 		id, email, passwordHash, name,
-		u.LowStockThreshold, u.NotificationEnabled,
+		u.LowStockThreshold,
 		user.ReconstructGramsPerCup(u.GramsPerCup),
 		u.CreatedAt.Time, u.UpdatedAt.Time,
 	)

--- a/backend/internal/repository/user_repository_test.go
+++ b/backend/internal/repository/user_repository_test.go
@@ -13,12 +13,10 @@ func TestUserRepository_Save(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		wantLowStockThreshold   int32
-		wantNotificationEnabled bool
+		wantLowStockThreshold int32
 	}{
 		"creates anonymous user with default values": {
-			wantLowStockThreshold:   100,
-			wantNotificationEnabled: true,
+			wantLowStockThreshold: 100,
 		},
 	}
 
@@ -39,9 +37,6 @@ func TestUserRepository_Save(t *testing.T) {
 			}
 			if u.LowStockThreshold() != tt.wantLowStockThreshold {
 				t.Errorf("LowStockThreshold = %d, want %d", u.LowStockThreshold(), tt.wantLowStockThreshold)
-			}
-			if u.NotificationEnabled() != tt.wantNotificationEnabled {
-				t.Errorf("NotificationEnabled = %v, want %v", u.NotificationEnabled(), tt.wantNotificationEnabled)
 			}
 		})
 	}
@@ -98,9 +93,6 @@ func TestUserRepository_GetByID(t *testing.T) {
 			}
 			if got.LowStockThreshold() != 100 {
 				t.Errorf("LowStockThreshold = %d, want 100", got.LowStockThreshold())
-			}
-			if !got.NotificationEnabled() {
-				t.Error("NotificationEnabled = false, want true")
 			}
 		})
 	}

--- a/backend/internal/usecase/auth_service.go
+++ b/backend/internal/usecase/auth_service.go
@@ -139,10 +139,9 @@ func (s *AuthService) GetMe(ctx context.Context, in GetMeInput) (*GetMeOutput, e
 
 // UpdateMeInput holds input for updating the current user's settings.
 type UpdateMeInput struct {
-	UserID              uuid.UUID
-	GramsPerCup         *int32
-	LowStockThreshold   *int32
-	NotificationEnabled *bool
+	UserID            uuid.UUID
+	GramsPerCup       *int32
+	LowStockThreshold *int32
 }
 
 // UpdateMeOutput holds the result of updating the current user.
@@ -157,7 +156,7 @@ func (s *AuthService) UpdateMe(ctx context.Context, in UpdateMeInput) (*UpdateMe
 		return nil, err
 	}
 
-	if err := u.Update(in.GramsPerCup, in.LowStockThreshold, in.NotificationEnabled); err != nil {
+	if err := u.Update(in.GramsPerCup, in.LowStockThreshold); err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/usecase/testhelpers_test.go
+++ b/backend/internal/usecase/testhelpers_test.go
@@ -18,7 +18,7 @@ func ptr[T any](v T) *T { return new(v) }
 
 func newTestUser(id uuid.UUID) *user.User {
 	now := time.Now()
-	return user.Reconstruct(id, "", "", "", 100, true, user.DefaultGramsPerCup(), now, now)
+	return user.Reconstruct(id, "", "", "", 100, user.DefaultGramsPerCup(), now, now)
 }
 
 func newTestBean(userID uuid.UUID) *coffeebean.CoffeeBean {

--- a/backend/migrations/000007_remove_notification_enabled.down.sql
+++ b/backend/migrations/000007_remove_notification_enabled.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN notification_enabled BOOLEAN NOT NULL DEFAULT true;

--- a/backend/migrations/000007_remove_notification_enabled.up.sql
+++ b/backend/migrations/000007_remove_notification_enabled.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN notification_enabled;

--- a/backend/sql/queries.sql
+++ b/backend/sql/queries.sql
@@ -3,8 +3,8 @@
 -- ============================================================================
 
 -- name: CreateAnonymousUser :one
-INSERT INTO users (id, low_stock_threshold, notification_enabled, grams_per_cup)
-VALUES ($1, $2, $3, $4)
+INSERT INTO users (id, low_stock_threshold, grams_per_cup)
+VALUES ($1, $2, $3)
 RETURNING *;
 
 -- name: GetUserByID :one
@@ -16,7 +16,6 @@ UPDATE users
 SET
     name = COALESCE(sqlc.narg('name'), name),
     low_stock_threshold = COALESCE(sqlc.narg('low_stock_threshold'), low_stock_threshold),
-    notification_enabled = COALESCE(sqlc.narg('notification_enabled'), notification_enabled),
     grams_per_cup = COALESCE(sqlc.narg('grams_per_cup'), grams_per_cup),
     updated_at = CURRENT_TIMESTAMP
 WHERE id = $1 AND deleted_at IS NULL

--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -9,7 +9,6 @@ CREATE TABLE users (
     password_hash VARCHAR(255),
     name VARCHAR(100),
     low_stock_threshold INTEGER NOT NULL DEFAULT 100,
-    notification_enabled BOOLEAN NOT NULL DEFAULT true,
     grams_per_cup INTEGER NOT NULL DEFAULT 15,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,

--- a/frontend/app/(tabs)/profile.tsx
+++ b/frontend/app/(tabs)/profile.tsx
@@ -73,15 +73,6 @@ export default function ProfileScreen() {
             <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
           </View>
         </TouchableOpacity>
-        <TouchableOpacity style={styles.settingRow} activeOpacity={0.7}>
-          <Text style={styles.settingLabel}>通知</Text>
-          <View style={styles.settingRight}>
-            <Text style={styles.settingValue}>
-              {user?.notification_enabled ? "ON" : "OFF"}
-            </Text>
-            <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
-          </View>
-        </TouchableOpacity>
         <TouchableOpacity style={[styles.settingRow, { borderBottomWidth: 0 }]} activeOpacity={0.7}>
           <Text style={styles.settingLabel}>1杯あたりのグラム数</Text>
           {editingGrams ? (

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -162,7 +162,6 @@ export interface components {
             name?: string;
             /** Format: int32 */
             low_stock_threshold?: number;
-            notification_enabled?: boolean;
             /** Format: int32 */
             grams_per_cup?: number;
             /** Format: date-time */
@@ -185,7 +184,6 @@ export interface components {
         UpdateUserRequest: {
             /** Format: int32 */
             low_stock_threshold?: number;
-            notification_enabled?: boolean;
             /** Format: int32 */
             grams_per_cup?: number;
         };


### PR DESCRIPTION
## Summary

- 実際の通知送信ロジックが存在しないため、`notification_enabled` はデッドコードと判断し全削除
- DB・ドメイン・リポジトリ・ユースケース・API・フロントエンドの全レイヤーから削除

## Changes

- `backend/migrations/000007_remove_notification_enabled` — カラム削除マイグレーション（up/down）
- `backend/sql/schema.sql` / `queries.sql` — `notification_enabled` 削除後 sqlc 再生成
- `backend/api/openapi.yaml` — `UserResponse` / `UpdateUserRequest` から削除後 oapi-codegen 再生成
- `backend/internal/domain/user/user.go` — フィールド・Reconstruct・Update・Getter 削除
- `backend/internal/usecase/auth_service.go` — `UpdateMeInput` から削除
- `backend/internal/repository/user_repository_impl.go` — Save/Update/toDomainUser から削除
- `backend/internal/api/handlers/auth_handler.go` — toUserResponse・UpdateMe から削除
- `frontend/app/(tabs)/profile.tsx` — 通知 ON/OFF 表示 UI を削除