### PR TITLE
feat(backend): エラーにスタックトレースを付与してデバッグ効率を向上させる

### DIFF
--- a/backend/internal/api/handlers/auth_handler.go
+++ b/backend/internal/api/handlers/auth_handler.go
@@ -44,7 +44,7 @@ func toUserResponse(u *user.User) gen.UserResponse {
 func (h *AuthHandler) RegisterAnonymous(w http.ResponseWriter, r *http.Request) {
 	result, err := h.authService.RegisterAnonymous(r.Context())
 	if err != nil {
-		api.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "サーバーエラーが発生しました")
+		handleDomainError(w, r, err, "")
 		return
 	}
 
@@ -73,7 +73,7 @@ func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 		RefreshToken: req.RefreshToken,
 	})
 	if err != nil {
-		handleDomainError(w, err, "リフレッシュトークンが無効です")
+		handleDomainError(w, r, err, "リフレッシュトークンが無効です")
 		return
 	}
 
@@ -92,7 +92,7 @@ func (h *AuthHandler) GetMe(w http.ResponseWriter, r *http.Request) {
 
 	output, err := h.authService.GetMe(r.Context(), usecase.GetMeInput{UserID: userID})
 	if err != nil {
-		api.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "サーバーエラーが発生しました")
+		handleDomainError(w, r, err, "ユーザーが見つかりません")
 		return
 	}
 
@@ -117,7 +117,7 @@ func (h *AuthHandler) UpdateMe(w http.ResponseWriter, r *http.Request) {
 		LowStockThreshold: req.LowStockThreshold,
 	})
 	if err != nil {
-		handleDomainError(w, err, "ユーザーが見つかりません")
+		handleDomainError(w, r, err, "ユーザーが見つかりません")
 		return
 	}
 

--- a/backend/internal/api/handlers/coffee_beans_handler.go
+++ b/backend/internal/api/handlers/coffee_beans_handler.go
@@ -71,7 +71,7 @@ func (h *CoffeeBeansHandler) List(w http.ResponseWriter, r *http.Request) {
 		Offset: offset,
 	})
 	if err != nil {
-		api.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "サーバーエラーが発生しました")
+		handleDomainError(w, r, err, "")
 		return
 	}
 
@@ -114,7 +114,7 @@ func (h *CoffeeBeansHandler) Create(w http.ResponseWriter, r *http.Request) {
 		CurrentStock: req.CurrentStock,
 	})
 	if err != nil {
-		handleDomainError(w, err, "コーヒー豆が見つかりません")
+		handleDomainError(w, r, err, "コーヒー豆が見つかりません")
 		return
 	}
 
@@ -138,7 +138,7 @@ func (h *CoffeeBeansHandler) Get(w http.ResponseWriter, r *http.Request) {
 		BeanID: beanID,
 	})
 	if err != nil {
-		handleDomainError(w, err, "コーヒー豆が見つかりません")
+		handleDomainError(w, r, err, "コーヒー豆が見つかりません")
 		return
 	}
 
@@ -173,7 +173,7 @@ func (h *CoffeeBeansHandler) Update(w http.ResponseWriter, r *http.Request) {
 		Notes:        req.Notes,
 	})
 	if err != nil {
-		handleDomainError(w, err, "コーヒー豆が見つかりません")
+		handleDomainError(w, r, err, "コーヒー豆が見つかりません")
 		return
 	}
 
@@ -196,7 +196,7 @@ func (h *CoffeeBeansHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		UserID: userID,
 		BeanID: beanID,
 	}); err != nil {
-		handleDomainError(w, err, "コーヒー豆が見つかりません")
+		handleDomainError(w, r, err, "コーヒー豆が見つかりません")
 		return
 	}
 

--- a/backend/internal/api/handlers/error_handler.go
+++ b/backend/internal/api/handlers/error_handler.go
@@ -1,38 +1,66 @@
 package handlers
 
 import (
+	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/k3forx/CoffeeBeansStock/backend/internal/api"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/api/middleware"
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/apperrors"
 	domain "github.com/k3forx/CoffeeBeansStock/backend/internal/domain"
 )
 
-// handleDomainError maps domain errors to HTTP responses.
-// notFoundMsg customizes the 404 message per resource type.
-func handleDomainError(w http.ResponseWriter, err error, notFoundMsg string) {
+// handleDomainError maps domain errors to HTTP responses and logs them.
+// notFoundMsg customizes the 404/401 message per resource type.
+func handleDomainError(w http.ResponseWriter, r *http.Request, err error, notFoundMsg string) {
 	var validationErrs domain.ValidationErrors
 	var validationErr *domain.ValidationError
 	switch {
 	case errors.As(err, &validationErrs):
+		logError(r.Context(), slog.LevelWarn, err)
 		details := make([]api.FieldError, len(validationErrs))
 		for i, ve := range validationErrs {
 			details[i] = api.FieldError{Field: ve.Field, Message: ve.Message}
 		}
 		api.WriteValidationError(w, details)
 	case errors.As(err, &validationErr):
+		logError(r.Context(), slog.LevelWarn, err)
 		api.WriteValidationError(w, []api.FieldError{
 			{Field: validationErr.Field, Message: validationErr.Message},
 		})
 	case errors.Is(err, domain.ErrNotFound):
+		logError(r.Context(), slog.LevelWarn, err)
 		api.WriteError(w, http.StatusNotFound, "NOT_FOUND", notFoundMsg)
 	case errors.Is(err, domain.ErrForbidden):
+		logError(r.Context(), slog.LevelWarn, err)
 		api.WriteError(w, http.StatusForbidden, "FORBIDDEN", "このリソースにアクセスする権限がありません")
 	case errors.Is(err, domain.ErrInsufficientStock):
+		logError(r.Context(), slog.LevelWarn, err)
 		api.WriteError(w, http.StatusConflict, "INSUFFICIENT_STOCK", "在庫が不足しています")
 	case errors.Is(err, domain.ErrInvalidToken), errors.Is(err, domain.ErrExpiredToken):
+		logError(r.Context(), slog.LevelWarn, err)
 		api.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", notFoundMsg)
 	default:
+		logError(r.Context(), slog.LevelError, err)
 		api.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "サーバーエラーが発生しました")
 	}
+}
+
+// logError logs an error at the specified level with optional stack trace.
+func logError(ctx context.Context, level slog.Level, err error) {
+	attrs := []slog.Attr{slog.String("error", err.Error())}
+	if stack, ok := apperrors.GetStackTrace(err); ok {
+		frames := make([]any, len(stack))
+		for i, f := range stack {
+			frames[i] = slog.GroupValue(
+				slog.String("func", f.Function),
+				slog.String("file", f.File),
+				slog.Int("line", f.Line),
+			)
+		}
+		attrs = append(attrs, slog.Any("stack_trace", frames))
+	}
+	middleware.LoggerFromContext(ctx).LogAttrs(ctx, level, "request error", attrs...)
 }

--- a/backend/internal/api/handlers/usage_history_handler.go
+++ b/backend/internal/api/handlers/usage_history_handler.go
@@ -47,7 +47,7 @@ func (h *UsageHistoryHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Notes:        req.Notes,
 	})
 	if err != nil {
-		handleDomainError(w, err, "リソースが見つかりません")
+		handleDomainError(w, r, err, "リソースが見つかりません")
 		return
 	}
 
@@ -76,7 +76,7 @@ func (h *UsageHistoryHandler) List(w http.ResponseWriter, r *http.Request) {
 		Offset:       offset,
 	})
 	if err != nil {
-		handleDomainError(w, err, "コーヒー豆が見つかりません")
+		handleDomainError(w, r, err, "コーヒー豆が見つかりません")
 		return
 	}
 
@@ -118,7 +118,7 @@ func (h *UsageHistoryHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		CoffeeBeanID: beanID,
 		UsageID:      usageID,
 	}); err != nil {
-		handleDomainError(w, err, "使用記録が見つかりません")
+		handleDomainError(w, r, err, "使用記録が見つかりません")
 		return
 	}
 

--- a/backend/internal/api/middleware/logging.go
+++ b/backend/internal/api/middleware/logging.go
@@ -47,3 +47,12 @@ func RequestLogger(next http.Handler) http.Handler {
 		slog.LogAttrs(r.Context(), level, "request completed", attrs...)
 	})
 }
+
+// LoggerFromContext returns the request-scoped logger stored by RequestLogger middleware.
+// Falls back to slog.Default() if not set.
+func LoggerFromContext(ctx context.Context) *slog.Logger {
+	if l, ok := ctx.Value(loggerKey{}).(*slog.Logger); ok {
+		return l
+	}
+	return slog.Default()
+}

--- a/backend/internal/api/response.go
+++ b/backend/internal/api/response.go
@@ -41,15 +41,7 @@ func WriteSuccess(w http.ResponseWriter, status int, data any) {
 }
 
 // WriteError writes an error JSON response.
-// For 5xx errors, it also logs the error details server-side.
 func WriteError(w http.ResponseWriter, status int, code, message string) {
-	if status >= 500 {
-		slog.Error("server error",
-			"status", status,
-			"code", code,
-			"message", message,
-		)
-	}
 	WriteJSON(w, status, Response{
 		Success: false,
 		Data:    nil,

--- a/backend/internal/apperrors/stack.go
+++ b/backend/internal/apperrors/stack.go
@@ -1,0 +1,38 @@
+package apperrors
+
+import "runtime"
+
+// Frame holds information about a single call frame.
+type Frame struct {
+	File     string
+	Line     int
+	Function string
+}
+
+// StackTrace is a slice of Frames representing the call stack.
+type StackTrace []Frame
+
+// captureStack captures the current call stack, skipping `skip` frames.
+// Callers pass skip=2 to start from the call site of Wrap/Wrapf.
+func captureStack(skip int) StackTrace {
+	const maxFrames = 32
+	pcs := make([]uintptr, maxFrames)
+	// +1 because runtime.Callers itself occupies frame 0.
+	n := runtime.Callers(skip+1, pcs)
+	if n == 0 {
+		return nil
+	}
+	frames := runtime.CallersFrames(pcs[:n])
+	st := make(StackTrace, 0, n)
+	for {
+		f, more := frames.Next()
+		if f.Function == "" {
+			break
+		}
+		st = append(st, Frame{File: f.File, Line: f.Line, Function: f.Function})
+		if !more {
+			break
+		}
+	}
+	return st
+}

--- a/backend/internal/apperrors/wrap.go
+++ b/backend/internal/apperrors/wrap.go
@@ -1,0 +1,67 @@
+package apperrors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// withStack wraps an error with a captured stack trace.
+type withStackError struct {
+	cause error
+	stack StackTrace
+}
+
+func (e *withStackError) Error() string {
+	return e.cause.Error()
+}
+
+func (e *withStackError) Unwrap() error {
+	return e.cause
+}
+
+func (e *withStackError) StackTrace() StackTrace {
+	return e.stack
+}
+
+// Wrap wraps err with a stack trace captured at the call site.
+// Returns nil if err is nil.
+// If err already contains a *withStack anywhere in its chain, returns err unchanged to prevent double-wrapping.
+func Wrap(err error) error {
+	if err == nil {
+		return nil
+	}
+	var ws *withStackError
+	if errors.As(err, &ws) {
+		return err
+	}
+	return &withStackError{cause: err, stack: captureStack(2)}
+}
+
+// Wrapf wraps err with a formatted message and a stack trace captured at the call site.
+// Returns nil if err is nil.
+// If err already contains a *withStack anywhere in its chain, returns err unchanged.
+func Wrapf(err error, format string, args ...any) error {
+	if err == nil {
+		return nil
+	}
+	var ws *withStackError
+	if errors.As(err, &ws) {
+		return err
+	}
+	// Append err as the last argument so %w binds to the original error.
+	safeArgs := make([]any, len(args)+1)
+	copy(safeArgs, args)
+	safeArgs[len(args)] = err
+	cause := fmt.Errorf(format+": %w", safeArgs...) //nolint:err113 // Wrapf intentionally creates a dynamic error for stack trace enrichment
+	return &withStackError{cause: cause, stack: captureStack(2)}
+}
+
+// GetStackTrace extracts the StackTrace from err if a *withStack is present in the chain.
+// Returns (nil, false) if no stack trace is found.
+func GetStackTrace(err error) (StackTrace, bool) {
+	var ws *withStackError
+	if errors.As(err, &ws) {
+		return ws.stack, true
+	}
+	return nil, false
+}

--- a/backend/internal/apperrors/wrap_test.go
+++ b/backend/internal/apperrors/wrap_test.go
@@ -1,0 +1,202 @@
+package apperrors
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var errBase = errors.New("base error")
+
+func TestWrap(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		input   error
+		wantNil bool
+	}{
+		"nilを渡すとnilを返す": {
+			input:   nil,
+			wantNil: true,
+		},
+		"エラーをラップするとwithStackErrorが返される": {
+			input:   errBase,
+			wantNil: false,
+		},
+		"すでにwithStackErrorを含むエラーは二重ラップしない": {
+			input:   Wrap(errBase),
+			wantNil: false,
+		},
+		"fmt.Errorfでラップされた中にwithStackErrorがある場合も二重ラップしない": {
+			input:   fmt.Errorf("outer: %w", Wrap(errBase)),
+			wantNil: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := Wrap(tt.input)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("Wrap() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Errorf("Wrap() = nil, want non-nil")
+				return
+			}
+			_, ok := GetStackTrace(got)
+			if !ok {
+				t.Errorf("Wrap() returned error without stack trace")
+			}
+		})
+	}
+}
+
+func TestWrap_ErrorsIs(t *testing.T) {
+	t.Parallel()
+	wrapped := Wrap(errBase)
+	if !errors.Is(wrapped, errBase) {
+		t.Errorf("errors.Is(Wrap(errBase), errBase) = false, want true")
+	}
+}
+
+func TestWrap_DoubleWrapReturnsSameError(t *testing.T) {
+	t.Parallel()
+	first := Wrap(errBase)
+	second := Wrap(first)
+	if first != second {
+		t.Errorf("二重ラップが防止されていない: Wrap(Wrap(err)) should return same error")
+	}
+}
+
+func TestWrapf(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		input   error
+		format  string
+		args    []any
+		wantNil bool
+	}{
+		"nilを渡すとnilを返す": {
+			input:   nil,
+			format:  "operation failed",
+			wantNil: true,
+		},
+		"フォーマットメッセージ付きでラップできる": {
+			input:  errBase,
+			format: "operation %s failed",
+			args:   []any{"save"},
+		},
+		"すでにwithStackErrorを含むエラーは二重ラップしない": {
+			input:  Wrap(errBase),
+			format: "outer",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := Wrapf(tt.input, tt.format, tt.args...)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("Wrapf() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Errorf("Wrapf() = nil, want non-nil")
+				return
+			}
+			_, ok := GetStackTrace(got)
+			if !ok {
+				t.Errorf("Wrapf() returned error without stack trace")
+			}
+		})
+	}
+}
+
+func TestWrapf_ErrorsIs(t *testing.T) {
+	t.Parallel()
+	wrapped := Wrapf(errBase, "operation failed")
+	if !errors.Is(wrapped, errBase) {
+		t.Errorf("errors.Is(Wrapf(errBase, ...), errBase) = false, want true")
+	}
+}
+
+func TestWrapf_MessageIncluded(t *testing.T) {
+	t.Parallel()
+	wrapped := Wrapf(errBase, "operation %s failed", "save")
+	want := "operation save failed: base error"
+	if got := wrapped.Error(); got != want {
+		t.Errorf("Wrapf().Error() = %q, want %q", got, want)
+	}
+}
+
+func TestGetStackTrace(t *testing.T) {
+	t.Parallel()
+
+	t.Run("スタックトレースが存在する場合はtrueを返す", func(t *testing.T) {
+		t.Parallel()
+		err := Wrap(errBase)
+		stack, ok := GetStackTrace(err)
+		if !ok {
+			t.Errorf("GetStackTrace() ok = false, want true")
+		}
+		if len(stack) == 0 {
+			t.Errorf("GetStackTrace() returned empty stack trace")
+		}
+	})
+
+	t.Run("スタックトレースが存在しない場合はfalseを返す", func(t *testing.T) {
+		t.Parallel()
+		_, ok := GetStackTrace(errBase)
+		if ok {
+			t.Errorf("GetStackTrace() ok = true, want false")
+		}
+	})
+
+	t.Run("スタックトレースに呼び出し元のフレームが含まれる", func(t *testing.T) {
+		t.Parallel()
+		err := Wrap(errBase)
+		stack, _ := GetStackTrace(err)
+		if len(stack) == 0 {
+			t.Fatal("stack trace is empty")
+		}
+		found := false
+		for _, f := range stack {
+			if strings.Contains(f.Function, "TestGetStackTrace") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("stack trace does not contain TestGetStackTrace frame: %+v", stack)
+		}
+	})
+
+	t.Run("フレーム情報が正しく設定される", func(t *testing.T) {
+		t.Parallel()
+		err := Wrap(errBase)
+		stack, _ := GetStackTrace(err)
+		if len(stack) == 0 {
+			t.Fatal("stack trace is empty")
+		}
+		first := stack[0]
+		if diff := cmp.Diff(false, first.File == ""); diff != "" {
+			t.Errorf("Frame.File should not be empty: %s", diff)
+		}
+		if first.Line == 0 {
+			t.Errorf("Frame.Line should not be 0")
+		}
+		if first.Function == "" {
+			t.Errorf("Frame.Function should not be empty")
+		}
+	})
+}

--- a/backend/internal/repository/coffee_bean_repository_impl.go
+++ b/backend/internal/repository/coffee_bean_repository_impl.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/apperrors"
 	"github.com/k3forx/CoffeeBeansStock/backend/internal/database"
 	"github.com/k3forx/CoffeeBeansStock/backend/internal/domain/coffeebean"
 )
@@ -40,7 +41,7 @@ func (r *coffeeBeanRepository) ListByUserID(ctx context.Context, userID uuid.UUI
 		Offset: offset,
 	})
 	if err != nil {
-		return nil, err
+		return nil, apperrors.Wrap(err)
 	}
 	beans := make([]*coffeebean.CoffeeBean, len(rows))
 	for i, row := range rows {
@@ -50,7 +51,8 @@ func (r *coffeeBeanRepository) ListByUserID(ctx context.Context, userID uuid.UUI
 }
 
 func (r *coffeeBeanRepository) CountByUserID(ctx context.Context, userID uuid.UUID) (int64, error) {
-	return r.queries.CountCoffeeBeansByUserID(ctx, toUUID(userID))
+	n, err := r.queries.CountCoffeeBeansByUserID(ctx, toUUID(userID))
+	return n, apperrors.Wrap(err)
 }
 
 func (r *coffeeBeanRepository) Save(ctx context.Context, bean *coffeebean.CoffeeBean) error {
@@ -68,7 +70,7 @@ func (r *coffeeBeanRepository) Save(ctx context.Context, bean *coffeebean.Coffee
 		params.RoastDetail = toPgText(&s)
 	}
 	_, err := r.queries.CreateCoffeeBean(ctx, params)
-	return err
+	return apperrors.Wrap(err)
 }
 
 func (r *coffeeBeanRepository) Update(ctx context.Context, bean *coffeebean.CoffeeBean) error {
@@ -97,14 +99,15 @@ func (r *coffeeBeanRepository) UpdateStock(ctx context.Context, id uuid.UUID, st
 		ID:           toUUID(id),
 		CurrentStock: stock.Value(),
 	})
-	return err
+	return apperrors.Wrap(err)
 }
 
 func (r *coffeeBeanRepository) SoftDelete(ctx context.Context, id, userID uuid.UUID) error {
-	return r.queries.SoftDeleteCoffeeBean(ctx, database.SoftDeleteCoffeeBeanParams{
+	err := r.queries.SoftDeleteCoffeeBean(ctx, database.SoftDeleteCoffeeBeanParams{
 		ID:     toUUID(id),
 		UserID: toUUID(userID),
 	})
+	return apperrors.Wrap(err)
 }
 
 func toDomainCoffeeBean(b database.CoffeeBean) *coffeebean.CoffeeBean {

--- a/backend/internal/repository/pgconv.go
+++ b/backend/internal/repository/pgconv.go
@@ -8,16 +8,20 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/apperrors"
 	domain "github.com/k3forx/CoffeeBeansStock/backend/internal/domain"
 )
 
-// notFoundOrErr converts pgx.ErrNoRows to domain.ErrNotFound.
-// All other errors (including nil) pass through unchanged.
+// notFoundOrErr converts pgx.ErrNoRows to domain.ErrNotFound (wrapped with stack trace).
+// All other non-nil errors are also wrapped with a stack trace.
 func notFoundOrErr(err error) error {
 	if errors.Is(err, pgx.ErrNoRows) {
-		return domain.ErrNotFound
+		return apperrors.Wrap(domain.ErrNotFound)
 	}
-	return err
+	if err != nil {
+		return apperrors.Wrap(err)
+	}
+	return nil
 }
 
 func toUUID(id uuid.UUID) pgtype.UUID {

--- a/backend/internal/repository/refresh_token_repository_impl.go
+++ b/backend/internal/repository/refresh_token_repository_impl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/apperrors"
 	"github.com/k3forx/CoffeeBeansStock/backend/internal/database"
 	domainauth "github.com/k3forx/CoffeeBeansStock/backend/internal/domain/auth"
 )
@@ -27,7 +28,7 @@ func (r *refreshTokenRepository) Store(ctx context.Context, userID uuid.UUID, to
 		TokenHash: tokenHash,
 		ExpiresAt: pgtype.Timestamptz{Time: expiresAt, Valid: true},
 	})
-	return err
+	return apperrors.Wrap(err)
 }
 
 func (r *refreshTokenRepository) ExistsByHash(ctx context.Context, tokenHash string) (bool, error) {
@@ -42,9 +43,11 @@ func (r *refreshTokenRepository) ExistsByHash(ctx context.Context, tokenHash str
 }
 
 func (r *refreshTokenRepository) DeleteByHash(ctx context.Context, tokenHash string) error {
-	return r.queries.DeleteRefreshTokenByHash(ctx, tokenHash)
+	err := r.queries.DeleteRefreshTokenByHash(ctx, tokenHash)
+	return apperrors.Wrap(err)
 }
 
 func (r *refreshTokenRepository) DeleteByUserID(ctx context.Context, userID uuid.UUID) error {
-	return r.queries.DeleteRefreshTokensByUserID(ctx, toUUID(userID))
+	err := r.queries.DeleteRefreshTokensByUserID(ctx, toUUID(userID))
+	return apperrors.Wrap(err)
 }

--- a/backend/internal/repository/usage_history_repository_impl.go
+++ b/backend/internal/repository/usage_history_repository_impl.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/apperrors"
 	"github.com/k3forx/CoffeeBeansStock/backend/internal/database"
 	domain "github.com/k3forx/CoffeeBeansStock/backend/internal/domain"
 	"github.com/k3forx/CoffeeBeansStock/backend/internal/domain/usagehistory"
@@ -35,7 +36,7 @@ func (r *usageHistoryRepository) ListByCoffeeBeanID(ctx context.Context, coffeeB
 		Offset:       offset,
 	})
 	if err != nil {
-		return nil, err
+		return nil, apperrors.Wrap(err)
 	}
 	usages := make([]*usagehistory.UsageHistory, len(rows))
 	for i, row := range rows {
@@ -45,7 +46,8 @@ func (r *usageHistoryRepository) ListByCoffeeBeanID(ctx context.Context, coffeeB
 }
 
 func (r *usageHistoryRepository) CountByCoffeeBeanID(ctx context.Context, coffeeBeanID uuid.UUID) (int64, error) {
-	return r.queries.CountUsageHistoriesByCoffeeBeanID(ctx, toUUID(coffeeBeanID))
+	n, err := r.queries.CountUsageHistoriesByCoffeeBeanID(ctx, toUUID(coffeeBeanID))
+	return n, apperrors.Wrap(err)
 }
 
 func (r *usageHistoryRepository) Save(ctx context.Context, usage *usagehistory.UsageHistory) error {
@@ -56,7 +58,7 @@ func (r *usageHistoryRepository) Save(ctx context.Context, usage *usagehistory.U
 		Quantity:     usage.Quantity().Value(),
 		Notes:        toPgText(usage.Notes()),
 	})
-	return err
+	return apperrors.Wrap(err)
 }
 
 func (r *usageHistoryRepository) GetRecentUsageSummary(ctx context.Context, coffeeBeanID uuid.UUID, since time.Time) (int32, error) {
@@ -65,7 +67,7 @@ func (r *usageHistoryRepository) GetRecentUsageSummary(ctx context.Context, coff
 		UsageDate:    toPgDate(since),
 	})
 	if err != nil {
-		return 0, err
+		return 0, apperrors.Wrap(err)
 	}
 	var total int32
 	for _, row := range rows {
@@ -80,7 +82,7 @@ func (r *usageHistoryRepository) GetRecentUsageSummaryByUserID(ctx context.Conte
 		UsageDate: toPgDate(since),
 	})
 	if err != nil {
-		return nil, err
+		return nil, apperrors.Wrap(err)
 	}
 	result := make(map[uuid.UUID]int32, len(rows))
 	for _, row := range rows {
@@ -92,10 +94,11 @@ func (r *usageHistoryRepository) GetRecentUsageSummaryByUserID(ctx context.Conte
 }
 
 func (r *usageHistoryRepository) Delete(ctx context.Context, id, userID uuid.UUID) error {
-	return r.queries.DeleteUsageHistory(ctx, database.DeleteUsageHistoryParams{
+	err := r.queries.DeleteUsageHistory(ctx, database.DeleteUsageHistoryParams{
 		ID:     toUUID(id),
 		UserID: toUUID(userID),
 	})
+	return apperrors.Wrap(err)
 }
 
 func toDomainUsageHistory(row database.UsageHistory) *usagehistory.UsageHistory {

--- a/backend/internal/repository/user_repository_impl.go
+++ b/backend/internal/repository/user_repository_impl.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/apperrors"
 	"github.com/k3forx/CoffeeBeansStock/backend/internal/database"
 	"github.com/k3forx/CoffeeBeansStock/backend/internal/domain/user"
 )
@@ -32,7 +33,7 @@ func (r *userRepository) Save(ctx context.Context, u *user.User) error {
 		LowStockThreshold: u.LowStockThreshold(),
 		GramsPerCup:       u.GramsPerCup().Value(),
 	})
-	return err
+	return apperrors.Wrap(err)
 }
 
 func (r *userRepository) Update(ctx context.Context, u *user.User) error {
@@ -44,7 +45,7 @@ func (r *userRepository) Update(ctx context.Context, u *user.User) error {
 		LowStockThreshold: pgtype.Int4{Int32: threshold, Valid: true},
 		GramsPerCup:       pgtype.Int4{Int32: gpc, Valid: true},
 	})
-	return err
+	return apperrors.Wrap(err)
 }
 
 func toDomainUser(u database.User) *user.User {

--- a/backend/internal/usecase/auth_service.go
+++ b/backend/internal/usecase/auth_service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/apperrors"
 	"github.com/k3forx/CoffeeBeansStock/backend/internal/auth"
 	domain "github.com/k3forx/CoffeeBeansStock/backend/internal/domain"
 	domainauth "github.com/k3forx/CoffeeBeansStock/backend/internal/domain/auth"
@@ -78,13 +79,13 @@ func (s *AuthService) Refresh(ctx context.Context, in RefreshInput) (*RefreshRes
 
 	userID, err := uuid.Parse(claims.UserID)
 	if err != nil {
-		return nil, domain.ErrInvalidToken
+		return nil, apperrors.Wrap(domain.ErrInvalidToken)
 	}
 
 	u, err := s.userRepo.GetByID(ctx, userID)
 	if err != nil {
 		if errors.Is(err, domain.ErrNotFound) {
-			return nil, domain.ErrInvalidToken
+			return nil, apperrors.Wrap(domain.ErrInvalidToken)
 		}
 		return nil, err
 	}
@@ -95,7 +96,7 @@ func (s *AuthService) Refresh(ctx context.Context, in RefreshInput) (*RefreshRes
 		return nil, err
 	}
 	if !exists {
-		return nil, domain.ErrInvalidToken
+		return nil, apperrors.Wrap(domain.ErrInvalidToken)
 	}
 	if err = s.refreshTokens.DeleteByHash(ctx, oldHash); err != nil {
 		return nil, err

--- a/backend/internal/usecase/coffee_beans_service.go
+++ b/backend/internal/usecase/coffee_beans_service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/k3forx/CoffeeBeansStock/backend/internal/apperrors"
 	domain "github.com/k3forx/CoffeeBeansStock/backend/internal/domain"
 	"github.com/k3forx/CoffeeBeansStock/backend/internal/domain/coffeebean"
 	"github.com/k3forx/CoffeeBeansStock/backend/internal/domain/unitofwork"
@@ -192,7 +193,7 @@ func (s *CoffeeBeansService) GetByID(ctx context.Context, in GetBeanByIDInput) (
 		return nil, err
 	}
 	if !bean.IsOwnedBy(in.UserID) {
-		return nil, domain.ErrForbidden
+		return nil, apperrors.Wrap(domain.ErrForbidden)
 	}
 
 	cr, err := s.computeConsumptionRate(ctx, in.BeanID, in.UserID, bean.CurrentStock().Value())
@@ -237,7 +238,7 @@ func (s *CoffeeBeansService) Update(ctx context.Context, in UpdateBeanInput) (*U
 			return err
 		}
 		if !bean.IsOwnedBy(in.UserID) {
-			return domain.ErrForbidden
+			return apperrors.Wrap(domain.ErrForbidden)
 		}
 		if err := bean.Update(in.Name, in.Origin, rl, rd, in.Notes, st); err != nil {
 			return err
@@ -270,7 +271,7 @@ func (s *CoffeeBeansService) Delete(ctx context.Context, in DeleteBeanInput) err
 			return err
 		}
 		if !bean.IsOwnedBy(in.UserID) {
-			return domain.ErrForbidden
+			return apperrors.Wrap(domain.ErrForbidden)
 		}
 		return store.CoffeeBeanRepo().SoftDelete(ctx, in.BeanID, in.UserID)
 	})


### PR DESCRIPTION
## Summary

- `internal/apperrors` パッケージを新規作成（`Wrap`/`Wrapf`/`GetStackTrace`）
- `runtime.Callers()` によるスタックトレース取得、二重ラップ防止
- repository 層・usecase 層の全エラー返却に `apperrors.Wrap()` を適用
- handler 層で 4xx（Warn）・5xx（Error）全エラーをスタックトレース付きで slog 出力
- domain 層は変更なし（DDD Lite の外部依存なし制約を維持）

## Changes

- `backend/internal/apperrors/stack.go` — `Frame`・`StackTrace` 型と `captureStack()` 実装
- `backend/internal/apperrors/wrap.go` — `Wrap`/`Wrapf`/`GetStackTrace` 実装、`Unwrap()` で `errors.Is`/`As` チェーン維持
- `backend/internal/apperrors/wrap_test.go` — ユニットテスト（テーブル駆動、日本語テストケース名）
- `backend/internal/repository/pgconv.go` — `notFoundOrErr` で全エラーをラップ（`domain.ErrNotFound` 含む）
- `backend/internal/repository/*_impl.go` — 直接 `return err` 箇所を `apperrors.Wrap(err)` に変更
- `backend/internal/usecase/*.go` — sentinel エラー直接返却に `apperrors.Wrap()` を適用
- `backend/internal/api/middleware/logging.go` — `LoggerFromContext` を追加（request_id 付きロガーの取得）
- `backend/internal/api/handlers/error_handler.go` — `logError(ctx, level, err)` を追加、全エラーケースでログ出力
- `backend/internal/api/response.go` — `WriteError` 内の二重ログを削除

## Acceptance Criteria

✅ `internal/apperrors/` パッケージが作成され、`Wrap()`/`Wrapf()`/`GetStackTrace()`関数が実装されている
✅ `Wrap()` でラップしたエラーに対して `errors.Is()`/`errors.As()` が正しく動作する（`Unwrap()` による）
✅ 二重ラップが防止される（`errors.As` でチェーン全体を確認、既に `withStackError` あればそのまま返す）
✅ repository 層の全エラー返却箇所で `apperrors.Wrap()` によりスタックトレースが付与されている
✅ usecase 層で直接 sentinel エラーを返す箇所に `apperrors.Wrap()` が適用されている
✅ handler 層の全エラーで slog にスタックトレース付きログが出力される（4xx: Warn、5xx: Error）
✅ domain 層に変更がない（外部依存なしの制約を維持）
✅ 既存テストが全て通過する
✅ `apperrors` パッケージのユニットテストが作成されている

## Related Issue

Closes #132

🤖 Generated with Claude Code
